### PR TITLE
No trailing semicolon in file filter ext. list

### DIFF
--- a/src/org.hdfgroup.hdfview/hdf/view/DefaultFileFilter.java
+++ b/src/org.hdfgroup.hdfview/hdf/view/DefaultFileFilter.java
@@ -123,7 +123,10 @@ public class DefaultFileFilter {
         String extString = "";
 
         while (extensions.hasMoreElements()) {
-            extString += "*." + extensions.nextElement() + ";";
+            extString += "*." + extensions.nextElement();
+            if (extensions.hasMoreElements()) {
+                extString += ";";
+            }
         }
 
         return extString;


### PR DESCRIPTION
The trailing semicolon breaks SWT `FileDialog` when backed by GTK's `GtkFileChooserNative` (injecting an invalid, empty, filter at the end...).