### PR TITLE
Set signtool path for ant build workflow

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -196,6 +196,7 @@ jobs:
       env:
         HDFLIBS: ${{ steps.set-hdflib-name.outputs.HDFLIB_ENV }}
         HDF5LIBS: ${{ steps.set-hdf5lib-name.outputs.HDF5LIB_ENV }}
+        SIGNTOOLDIR: "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.22621.0\\x64"
       run: |
         ant -noinput -buildfile build.xml binaryPackage
       shell: bash


### PR DESCRIPTION
This will remove `signtool not found error` during ant build process.