### PR TITLE
Correct versions in file(which will be replaced)

### DIFF
--- a/docs/RELEASE.txt
+++ b/docs/RELEASE.txt
@@ -17,14 +17,14 @@ Major Enhancements
 ==============================================================================
     * Build system converted to Maven
     * GH #117 Add User Option for editing the plugin path and include plugins.
-    * GH #138 Add Support for operating with float16 datatypes.
+    * GH #138 Add Support for operating with float16 and complex datatypes.
 
     ***** Previous fixes *****
     * GH #121 Updated all icons with transparency.
 
 Major Bug Fixes
 ==============================================================================
-    *
+    * 
 
     ***** Previous fixes *****
     * GH #119 (crashes opening HDF4 file) has been fixed. The problem was
@@ -51,6 +51,8 @@ Major Bug Fixes
 
 Minor Bug Fixes
 ==============================================================================
+    * GH #387 (checkHDF5Filters shows 'NONE') Replace corrupted tfilters.h5 test data file with correct version.
+    * GH #352 (isn't displaying attribute values correctly) Incorrectly using the array value as a character limit.
     * GH #159 (Help menu dialogs have gigantic images) Implemented by changing the size from 1024 to 256.
     * GH #171 (HDFView fails to find input files on command line when using relative paths)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update HDF5 version and document Maven build system conversion in `docs/RELEASE.txt`.
> 
>   - **Version Update**:
>     - Update HDF5 version from `1.15.x` to `2.x.y` in `docs/RELEASE.txt`.
>   - **Documentation**:
>     - Add "Build system converted to Maven" to Major Enhancements in `docs/RELEASE.txt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for c5aa26eb21fe91564c3ad912529b753d104aa0a7. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->