### PR TITLE
Replace broken javadoc links in UsersGuide

### DIFF
--- a/docs/UsersGuide/index.html
+++ b/docs/UsersGuide/index.html
@@ -31,7 +31,7 @@ User instructions for HDFView</li>
 A brief discussion of the HDF object model
 (Details of the HDF object model are available from
 
-<a href="javadocs/hdfview_java_doc/org.hdfgroup.object/module-summary.html">HDF Object Package</a>.)</li>
+<a href="https://support.hdfgroup.org/documentation/hdfview/latest/javadocs/hdfview_java_doc/org.hdfgroup.object/module-summary.html">HDF Object Package</a>.)</li>
 
 </ul>
 

--- a/docs/UsersGuide/ug03objects.html
+++ b/docs/UsersGuide/ug03objects.html
@@ -15,7 +15,7 @@
 <fieldset>Chapter 3: HDF Object Model</fieldset></h1>
 
 <p>
-This chapter provides basic information about the <a href="javadocs/hdfview_java_doc/org.hdfgroup.object/module-summary.html">HDF Object Model</a>.
+This chapter provides basic information about the <a href="https://support.hdfgroup.org/documentation/hdfview/latest/javadocs/hdfview_java_doc/org.hdfgroup.object/module-summary.html">HDF Object Model</a>.
 </p>
 <ul class="ul">
   <li class="add"><a href="ug03objects.html#ug03overview">3.1 Overview</a></li>
@@ -61,10 +61,10 @@ provides common standard Java APIs to access both HDF4 and HDF5 files.</p>
 libraries, and it requires the HDF4 and HDF5 wrappers.
 The HDF4 and HDF5 wrappers are separate HDF Java products. For
 details about the HDF4 and HDF5 native interfaces, see
-<a href="javadocs/hdf4_java_doc/overview-summary.html">
+<a href="https://support.hdfgroup.org/documentation/hdfview/latest/javadocs/hdf4_java_doc/index.html">
 Java HDF Interface (JHI)</a>
 and the
-<a href="javadocs/hdf5_java_doc/overview-summary.html">
+<a href="https://support.hdfgroup.org/documentation/hdfview/latest/javadocs/hdf5_java_doc/index.html">
 Java HDF5 Interface (JHI5)</a>.</p>
 
 <p>
@@ -105,7 +105,7 @@ classes, <b>Group</b>, <b>Datatype</b> and <b>Dataset</b>, and all HDF5 and HDF4
 are a sub-type of one of these abstract classes.</p>
 
 <p>For details, see the Java docs at
-<a href="javadocs/hdfview_java_doc/org.hdfgroup.object/module-summary.html">javadocs</a>.</p>
+<a href="https://support.hdfgroup.org/documentation/hdfview/latest/javadocs/hdfview_java_doc/org.hdfgroup.object/module-summary.html">javadocs</a>.</p>
 
 <br />
 <h2>
@@ -115,10 +115,10 @@ The HDF Object Package is used by Java applications to access HDF4 and
 HDF5 files without directly calling the HDF4 and HDF5 library APIs. Library
 calls are encapsulated into respective classes. The HDF Object Package
 requires the
-<a href="javadocs/hdf4_java_doc/overview-summary.html">
+<a href="https://support.hdfgroup.org/documentation/hdfview/latest/javadocs/hdf4_java_doc/index.html">
 Java HDF Interface (JHI)</a>
 and the
-<a href="javadocs/hdf5_java_doc/overview-summary.html">
+<a href="https://support.hdfgroup.org/documentation/hdfview/latest/javadocs/hdf5_java_doc/index.html">
 Java HDF5 Interface (JHI5)</a>.</p>
 <br />
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix broken javadoc links in `UsersGuide` documentation to point to the correct URLs on the HDF Group's website.
> 
>   - **Documentation**:
>     - Update broken javadoc links in `index.html` and `ug03objects.html` to point to `https://support.hdfgroup.org/documentation/hdfview/latest/javadocs/`.
>     - Links updated for `HDF Object Package`, `Java HDF Interface (JHI)`, and `Java HDF5 Interface (JHI5)`.
>     - Ensures users can access the correct documentation for HDF Object Model and Java interfaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 3a343652996fadd783c637e1daf97afb986f69ad. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->