### PR TITLE
Fix installer release uploads

### DIFF
--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -88,18 +88,20 @@ jobs:
               name: zip-tarball
               path: ${{ github.workspace }}
 
-      # Get files created by ant script
-      - name: Get published binary (Windows)
+      # Get platform installers created by jpackage
+      - name: Get Windows MSI installer
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-              name: zip-win-vs2022-binary
+              name: HDFView-${{ steps.get-file-base.outputs.VERSION }}-win64-msi
               path: ${{ github.workspace }}
+        continue-on-error: true # Allow workflow to continue if artifact not found
 
-      - name: Get published binary (MacOS)
+      - name: Get macOS DMG installer
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-              name: tgz-macos14_clang-binary
+              name: HDFView-${{ steps.get-file-base.outputs.VERSION }}-macOS-dmg
               path: ${{ github.workspace }}
+        continue-on-error: true # Allow workflow to continue if artifact not found
 
       - name: Get published binary (Linux)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -126,21 +128,6 @@ jobs:
               name: tgz-ubuntu-2404-app-binary
               path: ${{ github.workspace }}
 
-      # Get platform installers created by jpackage
-      - name: Get macOS DMG installer
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-              name: HDFView-${{ steps.get-file-base.outputs.VERSION }}-macOS-dmg
-              path: ${{ github.workspace }}
-        continue-on-error: true # Allow workflow to continue if artifact not found
-
-      - name: Get Windows MSI installer
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-              name: HDFView-${{ steps.get-file-base.outputs.VERSION }}-win64-msi
-              path: ${{ github.workspace }}
-        continue-on-error: true # Allow workflow to continue if artifact not found
-
       # Get files created by tarball script
       - name: Get UsersGuide (Linux)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -160,18 +147,16 @@ jobs:
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz >${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}.zip >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-Linux-x86_64.tar.gz >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-win64.zip >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}-Darwin.tar.gz >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}App-Linux-x86_64.tar.gz >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}App-win64.zip >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}App-Darwin.tar.gz >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          # Add platform installers if they exist
-          if [ -f "HDFView-${{ steps.get-file-base.outputs.VERSION }}.dmg" ]; then
-            sha256sum HDFView-${{ steps.get-file-base.outputs.VERSION }}.dmg >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
-          fi
+          # Add platform installers (MSI for Windows, DMG for macOS) if they exist
           if [ -f "HDFView-${{ steps.get-file-base.outputs.VERSION }}.msi" ]; then
             sha256sum HDFView-${{ steps.get-file-base.outputs.VERSION }}.msi >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           fi
+          if [ -f "HDFView-${{ steps.get-file-base.outputs.VERSION }}.dmg" ]; then
+            sha256sum HDFView-${{ steps.get-file-base.outputs.VERSION }}.dmg >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
+          fi
+          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}App-Linux-x86_64.tar.gz >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
+          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}App-win64.zip >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
+          sha256sum ${{ steps.get-file-base.outputs.FILE_BASE }}App-Darwin.tar.gz >>${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum UsersGuide.tar.gz >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
           sha256sum UsersGuide.zip >> ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
 
@@ -204,13 +189,11 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}-Linux-x86_64.tar.gz
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-win64.zip
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-Darwin.tar.gz
+              HDFView-${{ steps.get-file-base.outputs.VERSION }}.msi
+              HDFView-${{ steps.get-file-base.outputs.VERSION }}.dmg
               ${{ steps.get-file-base.outputs.FILE_BASE }}App-Linux-x86_64.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}App-win64.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}App-Darwin.tar.gz
-              HDFView-${{ steps.get-file-base.outputs.VERSION }}.dmg
-              HDFView-${{ steps.get-file-base.outputs.VERSION }}.msi
               ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
@@ -228,12 +211,10 @@ jobs:
               ${{ steps.get-file-base.outputs.FILE_BASE }}.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}-Linux-x86_64.tar.gz
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-win64.zip
-              ${{ steps.get-file-base.outputs.FILE_BASE }}-Darwin.tar.gz
+              HDFView-${{ steps.get-file-base.outputs.VERSION }}.msi
+              HDFView-${{ steps.get-file-base.outputs.VERSION }}.dmg
               ${{ steps.get-file-base.outputs.FILE_BASE }}App-Linux-x86_64.tar.gz
               ${{ steps.get-file-base.outputs.FILE_BASE }}App-win64.zip
               ${{ steps.get-file-base.outputs.FILE_BASE }}App-Darwin.tar.gz
-              HDFView-${{ steps.get-file-base.outputs.VERSION }}.dmg
-              HDFView-${{ steps.get-file-base.outputs.VERSION }}.msi
               ${{ steps.get-file-base.outputs.FILE_BASE }}.sha256sums.txt
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix installer release uploads by extracting version from file base and handling MSI/DMG artifacts in `release-files.yml`.
> 
>   - **Version Extraction**:
>     - Extracts version from `file_base` in `release-files.yml` to use in artifact names.
>   - **Artifact Handling**:
>     - Updates artifact names for Windows MSI and macOS DMG installers in `release-files.yml`.
>     - Adds `continue-on-error: true` for MSI and DMG downloads to allow workflow continuation if not found.
>   - **Checksum and Release**:
>     - Adds MSI and DMG files to SHA256 checksum generation in `release-files.yml`.
>     - Includes MSI and DMG files in release artifacts list for both pre-release and release tags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 5ef67180004ddd715e16a8fb0869096c6d94c723. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->