### PR TITLE
Fix installer signing on canonical repository

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -105,7 +105,16 @@ jobs:
       use_hdf5: snapshot
       use_hdf5_name: ${{ needs.get-base-names.outputs.hdf5-name }}
       use_environ: snapshots
-    secrets: inherit
+    secrets:
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      MACOS_DEVELOPER_ID: ${{ secrets.MACOS_DEVELOPER_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
     if: ${{ ((needs.call-workflow-tarball.outputs.has_changes == 'true') || (needs.get-base-names.outputs.run-ignore == 'ignore')) }}
 
   call-workflow-release:

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -50,6 +50,37 @@ on:
         type: boolean
         required: false
         default: false
+    secrets:
+      # macOS Code Signing
+      MACOS_CERTIFICATE:
+        description: 'macOS Developer ID certificate (base64 encoded)'
+        required: false
+      MACOS_CERT_PASSWORD:
+        description: 'Password for macOS certificate'
+        required: false
+      MACOS_KEYCHAIN_PASSWORD:
+        description: 'Password for temporary keychain'
+        required: false
+      MACOS_DEVELOPER_ID:
+        description: 'macOS Developer ID identity name'
+        required: false
+      # macOS Notarization
+      APPLE_ID:
+        description: 'Apple ID for notarization'
+        required: false
+      APPLE_ID_PASSWORD:
+        description: 'App-specific password for Apple ID'
+        required: false
+      APPLE_TEAM_ID:
+        description: 'Apple Developer Team ID'
+        required: false
+      # Windows Code Signing
+      WINDOWS_CERTIFICATE:
+        description: 'Windows code signing certificate (base64 encoded PFX)'
+        required: false
+      WINDOWS_CERT_PASSWORD:
+        description: 'Password for Windows certificate'
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,16 @@ jobs:
       snap_name: HDFView-${{ needs.call-workflow-tarball.outputs.source_base }}
       use_environ: release
       publish_to_maven_registry: true
-    secrets: inherit
+    secrets:
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      MACOS_DEVELOPER_ID: ${{ secrets.MACOS_DEVELOPER_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
 
   call-workflow-release:
     needs: [determine-version, call-workflow-tarball, call-workflow-maven-build]


### PR DESCRIPTION
## Summary

Fixes installer signing for macOS and Windows that was being skipped on the canonical HDFGroup/hdfview repository despite secrets being properly configured.

## Root Cause

The signing steps were using incorrect condition checks:
- `if: github.repository == 'HDFGroup/hdfview' && env.MACOS_CERTIFICATE != ''`
- `if: github.repository == 'HDFGroup/hdfview' && env.WINDOWS_CERTIFICATE != ''`

These environment variables are defined **inside** each step's `env:` block, so they don't exist when the `if:` condition is evaluated (conditions are evaluated before env blocks).

Additionally, secrets were passed using `secrets: inherit` instead of being explicitly defined and passed, which is less robust than the explicit approach used in the legacy ant workflows.

## Changes

### 1. Fix Signing Condition Checks (commit a1da530c)
Changed all signing condition checks from `env.*` to `secrets.*`:
- macOS signing steps (6 occurrences): Setup Keychain, Sign App Bundle, Sign DMG, Notarize DMG, Staple Ticket, Cleanup Keychain
- Windows signing steps (1 occurrence): Sign MSI Installer

### 2. Explicitly Define and Pass Secrets (commit ad2dbcb0)
- **maven-build.yml**: Added `secrets:` section defining all 9 required secrets
  - macOS: MACOS_CERTIFICATE, MACOS_CERT_PASSWORD, MACOS_KEYCHAIN_PASSWORD, MACOS_DEVELOPER_ID
  - Apple: APPLE_ID, APPLE_ID_PASSWORD, APPLE_TEAM_ID
  - Windows: WINDOWS_CERTIFICATE, WINDOWS_CERT_PASSWORD
  
- **daily-build.yml**: Replaced `secrets: inherit` with explicit secret passing
- **release.yml**: Replaced `secrets: inherit` with explicit secret passing

This follows GitHub Actions best practices and matches the pattern used in the legacy ant.yml/ant-app.yml workflows.

## Testing

- [x] Verified on fork (unsigned builds work correctly)
- [ ] Needs testing on canonical HDFGroup/hdfview to verify signing works

## Impact

- Enables code signing for macOS DMG installers (Developer ID + Notarization)
- Enables code signing for Windows MSI installers (Authenticode)
- No impact on unsigned builds (forks)
- Signing only occurs on canonical repository when secrets are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes installer signing for macOS and Windows by correcting condition checks and explicitly defining secrets in GitHub Actions workflows.
> 
>   - **Behavior**:
>     - Fixes signing condition checks in `maven-build.yml` by changing from `env.*` to `secrets.*` for macOS and Windows signing steps.
>     - Explicitly defines and passes secrets in `maven-build.yml`, `daily-build.yml`, and `release.yml` instead of using `secrets: inherit`.
>   - **Workflows**:
>     - `maven-build.yml`: Adds `secrets:` section with 9 required secrets for macOS and Windows signing.
>     - `daily-build.yml` and `release.yml`: Replaces `secrets: inherit` with explicit secret passing.
>   - **Impact**:
>     - Enables code signing for macOS DMG and Windows MSI installers on the canonical repository.
>     - No impact on unsigned builds (forks).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for ad2dbcb003552df289d0bc24ab28b12fe511b7b6. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->