### PR TITLE
Fix workflow validation error in maven-build.yml

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1543,6 +1543,15 @@ jobs:
     runs-on: macos-latest
     needs: build-macos-app
     timeout-minutes: 20
+    env:
+      # Set secrets as env vars at job level so they can be checked in step conditions
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      MACOS_DEVELOPER_ID: ${{ secrets.MACOS_DEVELOPER_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
     steps:
     - name: Checkout Code
@@ -1575,11 +1584,7 @@ jobs:
         ls -la
 
     - name: Setup Keychain and Certificate
-      if: github.repository == 'HDFGroup/hdfview' && secrets.MACOS_CERTIFICATE != ''
-      env:
-        MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-        MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-        MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      if: github.repository == 'HDFGroup/hdfview' && env.MACOS_CERTIFICATE != ''
       run: |
         echo "Setting up temporary keychain for code signing..."
 
@@ -1608,9 +1613,7 @@ jobs:
         echo "Keychain setup complete"
 
     - name: Sign App Bundle
-      if: github.repository == 'HDFGroup/hdfview' && secrets.MACOS_CERTIFICATE != ''
-      env:
-        MACOS_DEVELOPER_ID: ${{ secrets.MACOS_DEVELOPER_ID }}
+      if: github.repository == 'HDFGroup/hdfview' && env.MACOS_CERTIFICATE != ''
       run: |
         echo "Code signing app bundle..."
 
@@ -1664,9 +1667,7 @@ jobs:
         ls -lh *.dmg
 
     - name: Sign DMG Installer
-      if: github.repository == 'HDFGroup/hdfview' && secrets.MACOS_CERTIFICATE != ''
-      env:
-        MACOS_DEVELOPER_ID: ${{ secrets.MACOS_DEVELOPER_ID }}
+      if: github.repository == 'HDFGroup/hdfview' && env.MACOS_CERTIFICATE != ''
       run: |
         echo "Code signing DMG installer..."
 
@@ -1695,11 +1696,7 @@ jobs:
         echo "DMG installer signed successfully"
 
     - name: Notarize DMG
-      if: github.repository == 'HDFGroup/hdfview' && secrets.MACOS_CERTIFICATE != ''
-      env:
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      if: github.repository == 'HDFGroup/hdfview' && env.MACOS_CERTIFICATE != ''
       run: |
         echo "Submitting DMG for notarization..."
 
@@ -1731,7 +1728,7 @@ jobs:
         echo "Notarization completed successfully"
 
     - name: Staple Notarization Ticket
-      if: github.repository == 'HDFGroup/hdfview' && secrets.MACOS_CERTIFICATE != ''
+      if: github.repository == 'HDFGroup/hdfview' && env.MACOS_CERTIFICATE != ''
       run: |
         echo "Stapling notarization ticket to DMG..."
 
@@ -1756,7 +1753,7 @@ jobs:
         echo "Notarization ticket stapled successfully"
 
     - name: Cleanup Keychain
-      if: always() && github.repository == 'HDFGroup/hdfview' && secrets.MACOS_CERTIFICATE != ''
+      if: always() && github.repository == 'HDFGroup/hdfview' && env.MACOS_CERTIFICATE != ''
       run: |
         security delete-keychain build.keychain || true
 
@@ -1772,6 +1769,10 @@ jobs:
     runs-on: windows-latest
     needs: build-windows-app
     timeout-minutes: 20
+    env:
+      # Set secrets as env vars at job level so they can be checked in step conditions
+      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+      WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
 
     steps:
     - name: Checkout Code
@@ -1846,11 +1847,8 @@ jobs:
         Get-ChildItem *.msi
 
     - name: Sign MSI Installer
-      if: github.repository == 'HDFGroup/hdfview' && secrets.WINDOWS_CERTIFICATE != ''
+      if: github.repository == 'HDFGroup/hdfview' && env.WINDOWS_CERTIFICATE != ''
       shell: pwsh
-      env:
-        WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-        WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
       run: |
         Write-Host "Signing MSI installer..."
 


### PR DESCRIPTION
## Summary

Fixes the workflow validation error introduced in PR #419 that prevents workflows from running:

```
error parsing called workflow: Unrecognized named-value: 'secrets'. 
Located at position 44 within expression: github.repository == 'HDFGroup/hdfview' && secrets.MACOS_CERTIFICATE != ''
```

## Root Cause

GitHub Actions does not allow `secrets.*` to be referenced in step-level `if:` conditions. Only specific contexts are available in step conditions: `github`, `needs`, `steps`, `job`, `runner`, `env`, `matrix`, `inputs`.

PR #419 changed the conditions from `env.*` to `secrets.*` which caused validation to fail.

## Solution

Set secrets as environment variables at the **job level** (not step level), then reference them using `env.*` in step conditions:

1. **build-macos-installer job**: Added job-level `env:` block with all macOS/Apple secrets
2. **build-windows-installer job**: Added job-level `env:` block with Windows secrets  
3. **All signing steps**: Changed conditions from `secrets.*` back to `env.*`
4. **Cleanup**: Removed redundant step-level `env:` blocks (vars now set at job level)

## Changes

```yaml
jobs:
  build-macos-installer:
    env:
      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
      # ... all other secrets
    steps:
      - name: Setup Keychain
        if: env.MACOS_CERTIFICATE != ''  # ✓ Works (was secrets.MACOS_CERTIFICATE)
```

## Testing

- [x] Workflow syntax validates correctly
- [ ] Needs testing on canonical to verify signing still works

## Impact

- Fixes workflow validation error blocking all workflow runs
- Signing will work correctly once secrets are properly configured
- No functional changes to the signing logic itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes workflow validation error in `maven-build.yml` by setting secrets as job-level environment variables and using `env.*` in step conditions.
> 
>   - **Behavior**:
>     - Fixes workflow validation error in `maven-build.yml` by changing secret references from `secrets.*` to `env.*` in step conditions.
>     - Sets secrets as environment variables at the job level for `build-macos-installer` and `build-windows-installer` jobs.
>   - **Jobs**:
>     - `build-macos-installer`: Adds job-level `env:` block with macOS secrets.
>     - `build-windows-installer`: Adds job-level `env:` block with Windows secrets.
>   - **Steps**:
>     - Updates all signing steps to use `env.*` for conditions instead of `secrets.*`.
>     - Removes redundant step-level `env:` blocks in `maven-build.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 4abd27715ed5171997e699d776ce465412e9d184. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->