### PR TITLE
Add debug output to diagnose signing secret issues

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1583,6 +1583,18 @@ jobs:
         tar -xzf ${{ inputs.file_base }}App-Darwin.tar.gz
         ls -la
 
+    - name: Debug - Check Signing Secrets
+      run: |
+        echo "Repository: ${{ github.repository }}"
+        echo "MACOS_CERTIFICATE is set: ${{ env.MACOS_CERTIFICATE != '' }}"
+        echo "MACOS_DEVELOPER_ID is set: ${{ env.MACOS_DEVELOPER_ID != '' }}"
+        echo "APPLE_ID is set: ${{ env.APPLE_ID != '' }}"
+        if [ -n "$MACOS_CERTIFICATE" ]; then
+          echo "✓ MACOS_CERTIFICATE has value (length: ${#MACOS_CERTIFICATE})"
+        else
+          echo "✗ MACOS_CERTIFICATE is empty or not set"
+        fi
+
     - name: Setup Keychain and Certificate
       if: github.repository == 'HDFGroup/hdfview' && env.MACOS_CERTIFICATE != ''
       run: |
@@ -1834,6 +1846,17 @@ jobs:
 
         Write-Host "MSI installer created successfully"
         Get-ChildItem *.msi
+
+    - name: Debug - Check Signing Secrets
+      shell: pwsh
+      run: |
+        Write-Host "Repository: ${{ github.repository }}"
+        Write-Host "WINDOWS_CERTIFICATE is set: ${{ env.WINDOWS_CERTIFICATE != '' }}"
+        if ($env:WINDOWS_CERTIFICATE) {
+          Write-Host "✓ WINDOWS_CERTIFICATE has value (length: $($env:WINDOWS_CERTIFICATE.Length))"
+        } else {
+          Write-Host "✗ WINDOWS_CERTIFICATE is empty or not set"
+        }
 
     - name: Rename MSI for snapshots
       if: inputs.use_environ == 'snapshots'


### PR DESCRIPTION
## Summary

Adds debug output to help diagnose why installer signing steps are being skipped on the canonical repository despite secrets being configured.

## Current Issue

After merging PR #419 and PR #420, signing steps are still being skipped. The condition `env.MACOS_CERTIFICATE != ''` is evaluating to false, but we need to understand why.

## Debug Output Added

This PR adds two debug steps that will show:

**macOS Installer Job:**
- Repository name
- Whether `MACOS_CERTIFICATE` is set (boolean)
- Whether `MACOS_DEVELOPER_ID` is set (boolean)
- Whether `APPLE_ID` is set (boolean)
- Length of certificate value if it exists

**Windows Installer Job:**
- Repository name
- Whether `WINDOWS_CERTIFICATE` is set (boolean)
- Length of certificate value if it exists

## Expected Output Examples

**If secrets are properly configured:**
```
Repository: HDFGroup/hdfview
MACOS_CERTIFICATE is set: true
MACOS_DEVELOPER_ID is set: true
APPLE_ID is set: true
✓ MACOS_CERTIFICATE has value (length: 2847)
```

**If secrets are missing:**
```
Repository: HDFGroup/hdfview
MACOS_CERTIFICATE is set: false
MACOS_DEVELOPER_ID is set: false
APPLE_ID is set: false
✗ MACOS_CERTIFICATE is empty or not set
```

## Next Steps

1. Merge this PR
2. Run a workflow (daily-build or release)
3. Check the debug output in the "Debug - Check Signing Secrets" step
4. Based on the output, we can determine if:
   - Secrets aren't configured in the repository
   - Secrets are empty
   - Secrets aren't being passed correctly
   - There's another issue with the condition logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add debug steps in `maven-build.yml` to log signing secret statuses for macOS and Windows installers.
> 
>   - **Debug Steps Added**:
>     - In `maven-build.yml`, added `Debug - Check Signing Secrets` step for macOS and Windows installer jobs.
>     - Logs repository name and checks if `MACOS_CERTIFICATE`, `MACOS_DEVELOPER_ID`, `APPLE_ID`, and `WINDOWS_CERTIFICATE` are set.
>     - Logs length of `MACOS_CERTIFICATE` and `WINDOWS_CERTIFICATE` if set.
>   - **Purpose**:
>     - Diagnose why signing steps are skipped despite secrets being configured.
>     - Helps identify if secrets are missing, empty, or not passed correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 3a1ed5b9a564c530775f5f9dc831f7012345e3f7. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->