### PR TITLE
Fix signing implementation errors from testing

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1624,7 +1624,7 @@ jobs:
 
         # Allow codesign to access keychain
         security set-key-partition-list -S apple-tool:,apple: \
-          -k "$MACOS_KEYCHAIN_PASSWORD" \
+          -k "$KEYCHAIN_PASSWD" \
           build.keychain
 
         # Clean up certificate file
@@ -1901,16 +1901,15 @@ jobs:
         # Install Azure Code Signing tools
         dotnet tool install --global AzureSignTool --version 5.0.0
 
-        # Sign using Azure Code Signing
+        # Sign using Azure Key Vault
         AzureSignTool sign `
-          -du "${{ env.AZURE_ENDPOINT }}" `
-          -kvu "${{ env.AZURE_ENDPOINT }}" `
-          -kvt "${{ env.AZURE_TENANT_ID }}" `
-          -kvi "${{ env.AZURE_CLIENT_ID }}" `
-          -kvs "${{ env.AZURE_CLIENT_SECRET }}" `
-          -kvc "${{ env.AZURE_CERT_PROFILE_NAME }}" `
-          -tr "http://timestamp.digicert.com" `
-          -v `
+          --azure-key-vault-url "${{ env.AZURE_ENDPOINT }}" `
+          --azure-key-vault-tenant-id "${{ env.AZURE_TENANT_ID }}" `
+          --azure-key-vault-client-id "${{ env.AZURE_CLIENT_ID }}" `
+          --azure-key-vault-client-secret "${{ env.AZURE_CLIENT_SECRET }}" `
+          --azure-key-vault-certificate "${{ env.AZURE_CERT_PROFILE_NAME }}" `
+          --timestamp-rfc3161 "http://timestamp.digicert.com" `
+          --verbose `
           $msiFile
 
         if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
Fixes critical signing errors discovered during testing of PR #422.

## Issues Found

After merging PR #422, testing revealed two implementation errors:

### 1. macOS Keychain Error
security: SecKeychainItemSetAccessWithPassword: The user name or passphrase you entered is not correct.

Root Cause: The security set-key-partition-list command was using the old variable name MACOS_KEYCHAIN_PASSWORD which no longer exists after renaming to KEYCHAIN_PASSWD.

### 2. Windows Azure Signing Error
Failed to retrieve certificate from Azure Key Vault. Status: 403 (Forbidden)

Root Cause: AzureSignTool parameters were using incorrect short-form flags. The tool requires full parameter names for Azure Key Vault signing.

## Changes

### macOS Keychain Fix
Changed security set-key-partition-list to use KEYCHAIN_PASSWD instead of MACOS_KEYCHAIN_PASSWORD

### Windows Azure Signing Fix
Updated AzureSignTool to use full parameter names:
- --azure-key-vault-url
- --azure-key-vault-tenant-id
- --azure-key-vault-client-id
- --azure-key-vault-client-secret
- --azure-key-vault-certificate
- --timestamp-rfc3161

## Additional Notes

The Windows 403 error may also indicate Azure Key Vault permission issues. If the error persists, verify:
1. The service principal has Get and Sign permissions on the certificate
2. The certificate name matches the actual certificate in the Key Vault
3. The AZURE_ENDPOINT URL is correct

🤖 Generated with Claude Code
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes macOS keychain and Windows Azure signing errors in `.github/workflows/maven-build.yml`.
> 
>   - **macOS Keychain Fix**:
>     - Updated `security set-key-partition-list` to use `KEYCHAIN_PASSWD` instead of `MACOS_KEYCHAIN_PASSWORD` in `.github/workflows/maven-build.yml`.
>   - **Windows Azure Signing Fix**:
>     - Updated `AzureSignTool` command in `.github/workflows/maven-build.yml` to use full parameter names: `--azure-key-vault-url`, `--azure-key-vault-tenant-id`, `--azure-key-vault-client-id`, `--azure-key-vault-client-secret`, `--azure-key-vault-certificate`, `--timestamp-rfc3161`.
>   - **Additional Notes**:
>     - Windows 403 error may indicate Azure Key Vault permission issues. Verify service principal permissions and certificate name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 734f588dda2e1e2d4499202395517214f3493928. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->