### PR TITLE
Fix Windows MSI signing using Microsoft Trusted Signing

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1908,11 +1908,27 @@ jobs:
         Move-Item -Path $oldName -Destination $newName
         Get-ChildItem *.msi
 
-    - name: Sign MSI Installer with Azure Code Signing
+    - name: Install Microsoft Trusted Signing
       if: github.repository == 'HDFGroup/hdfview' && env.AZURE_TENANT_ID != ''
       shell: pwsh
       run: |
-        Write-Host "Signing MSI installer with Azure Code Signing..."
+        Write-Host "Installing Microsoft Trusted Signing tools..."
+        Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile .\nuget.exe
+        .\nuget.exe install Microsoft.Windows.SDK.BuildTools -Version 10.0.22621.3233 -x
+        .\nuget.exe install Microsoft.Trusted.Signing.Client -Version 1.0.53 -x
+
+    - name: Create Trusted Signing credentials file
+      if: github.repository == 'HDFGroup/hdfview' && env.AZURE_TENANT_ID != ''
+      uses: jsdaniell/create-json@v1.2.3
+      with:
+        name: "credentials.json"
+        json: '{"Endpoint": "${{ env.AZURE_ENDPOINT }}","CodeSigningAccountName": "${{ env.AZURE_CODE_SIGNING_NAME }}","CertificateProfileName": "${{ env.AZURE_CERT_PROFILE_NAME }}"}'
+
+    - name: Sign MSI Installer with Microsoft Trusted Signing
+      if: github.repository == 'HDFGroup/hdfview' && env.AZURE_TENANT_ID != ''
+      shell: pwsh
+      run: |
+        Write-Host "Signing MSI installer with Microsoft Trusted Signing..."
 
         # Determine MSI filename (snapshot includes commit SHA, release uses version only)
         $version = "${{ steps.get-version.outputs.HDFVIEW_VERSION }}"
@@ -1923,28 +1939,29 @@ jobs:
         }
 
         Write-Host "Signing MSI: $msiFile"
-        Write-Host "Using Azure Code Signing service"
 
-        # Install Azure Code Signing tools
-        dotnet tool install --global AzureSignTool --version 5.0.0
+        # Set paths
+        $signtoolPath = "${{ github.workspace }}/Microsoft.Windows.SDK.BuildTools/bin/10.0.22621.0/x64/signtool.exe"
+        $dllPath = "${{ github.workspace }}/Microsoft.Trusted.Signing.Client/bin/x64/Azure.CodeSigning.Dlib.dll"
+        $metadataPath = "${{ github.workspace }}/credentials.json"
 
-        # Sign using Azure Key Vault
-        AzureSignTool sign `
-          --azure-key-vault-url "${{ env.AZURE_ENDPOINT }}" `
-          --azure-key-vault-tenant-id "${{ env.AZURE_TENANT_ID }}" `
-          --azure-key-vault-client-id "${{ env.AZURE_CLIENT_ID }}" `
-          --azure-key-vault-client-secret "${{ env.AZURE_CLIENT_SECRET }}" `
-          --azure-key-vault-certificate "${{ env.AZURE_CERT_PROFILE_NAME }}" `
-          --timestamp-rfc3161 "http://timestamp.digicert.com" `
-          --verbose `
+        # Sign using Microsoft Trusted Signing
+        & $signtoolPath sign `
+          /v `
+          /debug `
+          /fd SHA256 `
+          /tr "http://timestamp.acs.microsoft.com" `
+          /td SHA256 `
+          /dlib $dllPath `
+          /dmdf $metadataPath `
           $msiFile
 
         if ($LASTEXITCODE -ne 0) {
-          Write-Error "Azure Code Signing failed with exit code $LASTEXITCODE"
+          Write-Error "Signing failed with exit code $LASTEXITCODE"
           exit $LASTEXITCODE
         }
 
-        Write-Host "MSI installer signed successfully with Azure Code Signing"
+        Write-Host "MSI installer signed successfully"
 
     - name: Upload Windows MSI Installer
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fixes Windows MSI installer signing by using Microsoft's official Trusted Signing tools, matching the proven working implementation from ant.yml.

## Problem
Windows signing was failing with 403 Forbidden error because it was using AzureSignTool (third-party tool) instead of Microsoft's official Trusted Signing.

## Solution
Replaced AzureSignTool with Microsoft Trusted Signing to match ant.yml implementation:

1. Install Microsoft.Windows.SDK.BuildTools and Microsoft.Trusted.Signing.Client via nuget
2. Create credentials.json with Azure endpoint and certificate profile  
3. Use signtool with Azure.CodeSigning.Dlib.dll

## Changes
- Install nuget packages (same versions as ant.yml lines 230-236)
- Create credentials.json using jsdaniell/create-json action (matches ant.yml lines 239-245)
- Sign with signtool using /dlib and /dmdf parameters
- Use Microsoft timestamp server: http://timestamp.acs.microsoft.com

This exactly matches the working approach from ant.yml lines 230-261.

## Testing
Branch created on canonical repository so secrets will be available for testing.

🤖 Generated with Claude Code
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces AzureSignTool with Microsoft Trusted Signing for Windows MSI signing in `maven-build.yml`, ensuring integrity and consistency with proven methods.
> 
>   - **Behavior**:
>     - Replaces AzureSignTool with Microsoft Trusted Signing in `maven-build.yml` for Windows MSI signing.
>     - Uses `signtool` with `Azure.CodeSigning.Dlib.dll` and Microsoft timestamp server.
>   - **Setup**:
>     - Installs `Microsoft.Windows.SDK.BuildTools` and `Microsoft.Trusted.Signing.Client` via `nuget`.
>     - Creates `credentials.json` using `jsdaniell/create-json` action.
>   - **Testing**:
>     - Branch created on canonical repository to access secrets for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 45bcb680ae71bc699d4ff66f5821996eca5be1eb. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->