### PR TITLE
Fix macOS keychain setup using ant.yml approach

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1632,30 +1632,27 @@ jobs:
 
     - name: Setup Keychain and Certificate
       if: github.repository == 'HDFGroup/hdfview' && env.APPLE_CERTS_BASE64 != ''
+      shell: bash
       run: |
         echo "Setting up temporary keychain for code signing..."
 
-        # Create temporary keychain
-        security create-keychain -p "$KEYCHAIN_PASSWD" build.keychain
-        security default-keychain -s build.keychain
-        security unlock-keychain -p "$KEYCHAIN_PASSWD" build.keychain
-        security set-keychain-settings build.keychain
+        # Create variables (matching ant.yml)
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        KEYCHAIN_FILE=build.keychain
 
-        # Decode and import certificate
-        echo "$APPLE_CERTS_BASE64" | base64 --decode > certificate.p12
-        security import certificate.p12 \
-          -k build.keychain \
-          -P "$APPLE_CERTS_BASE64_PASSWD" \
-          -T /usr/bin/codesign \
-          -T /usr/bin/productsign
+        # Import certificate from secrets
+        echo $APPLE_CERTS_BASE64 | base64 --decode > $CERTIFICATE_PATH
 
-        # Allow codesign to access keychain
-        security set-key-partition-list -S apple-tool:,apple: \
-          -k "$KEYCHAIN_PASSWD" \
-          build.keychain
+        # Create keychain
+        security -v create-keychain -p $KEYCHAIN_PASSWD $KEYCHAIN_FILE
+        security -v list-keychain -d user -s $KEYCHAIN_FILE
+        security -v list-keychains
+        security -v set-keychain-settings -lut 21600 $KEYCHAIN_FILE
+        security -v unlock-keychain -p $KEYCHAIN_PASSWD $KEYCHAIN_FILE
 
-        # Clean up certificate file
-        rm certificate.p12
+        # Import certificate to keychain
+        security -v import $CERTIFICATE_PATH -P $APPLE_CERTS_BASE64_PASSWD -A -t cert -f pkcs12 -k $KEYCHAIN_FILE
+        security -v set-key-partition-list -S apple-tool:,codesign:,apple: -k $KEYCHAIN_PASSWD $KEYCHAIN_FILE
 
         echo "Keychain setup complete"
 


### PR DESCRIPTION
Fixes macOS keychain setup by exactly matching the proven working implementation from ant.yml.

## Problem
macOS signing was failing with keychain permission error because the keychain setup didn't match the working ant.yml implementation.

## Solution
Updated keychain setup to exactly match ant.yml lines 472-492:

1. Use CERTIFICATE_PATH and KEYCHAIN_FILE variables
2. Add -v flag for verbose security output
3. Use list-keychain -d user -s instead of default-keychain
4. Add list-keychains for debugging
5. Set keychain timeout: -lut 21600 (6 hours)
6. Import with -A flag (allow all apps access)
7. Import with -t cert -f pkcs12 flags
8. Use -S apple-tool:,codesign:,apple: (includes codesign)

## Key Changes
- security list-keychain -d user -s (not default-keychain)
- security set-keychain-settings -lut 21600 (add timeout)
- security import with -A -t cert -f pkcs12 flags
- security set-key-partition-list with apple-tool:,codesign:,apple:

This exactly matches the working ant.yml implementation.

## Testing
Branch created on canonical repository so secrets will be available for testing.

🤖 Generated with Claude Code
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix macOS keychain setup in `maven-build.yml` to match `ant.yml` configuration, resolving signing permission errors.
> 
>   - **Keychain Setup**:
>     - Update keychain setup in `maven-build.yml` to match `ant.yml` lines 472-492.
>     - Use `CERTIFICATE_PATH` and `KEYCHAIN_FILE` variables for keychain and certificate paths.
>     - Add `-v` flag for verbose output in `security` commands.
>     - Use `list-keychain -d user -s` instead of `default-keychain`.
>     - Set keychain timeout with `-lut 21600` (6 hours).
>     - Import certificate with `-A`, `-t cert`, `-f pkcs12` flags.
>     - Set key partition list with `apple-tool:,codesign:,apple:`.
>   - **Testing**:
>     - Branch created on canonical repository to ensure secrets are available for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for b4a84e7341355950b8e3d02a5ae77ba008e03cce. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->