### PR TITLE
Fix debug secret checks to use correct variable names

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1587,6 +1587,11 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      # Repository variables for signing (matching ant.yml)
+      KEYCHAIN_NAME: ${{ vars.KEYCHAIN_NAME }}
+      SIGNER: ${{ vars.SIGNER }}
+      NOTARY_USER: ${{ vars.NOTARY_USER }}
+      NOTARY_KEY: ${{ vars.NOTARY_KEY }}
 
     steps:
     - name: Checkout Code
@@ -1636,9 +1641,9 @@ jobs:
       run: |
         echo "Setting up temporary keychain for code signing..."
 
-        # Create variables (matching ant.yml)
+        # Create variables (matching ant.yml exactly)
         CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
-        KEYCHAIN_FILE=build.keychain
+        KEYCHAIN_FILE=$KEYCHAIN_NAME.keychain
 
         # Import certificate from secrets
         echo $APPLE_CERTS_BASE64 | base64 --decode > $CERTIFICATE_PATH
@@ -1660,12 +1665,13 @@ jobs:
       if: github.repository == 'HDFGroup/hdfview' && env.APPLE_CERTS_BASE64 != ''
       run: |
         echo "Code signing app bundle..."
+        echo "Using identity: $SIGNER"
 
         # Sign the app bundle
         codesign --force --timestamp --options runtime \
           --entitlements lib/macosx/distribution.entitlements \
           --verbose=4 --strict \
-          --sign "$MACOS_DEVELOPER_ID" \
+          --sign "$SIGNER" \
           --deep \
           HDFView.app
 
@@ -1714,6 +1720,7 @@ jobs:
       if: github.repository == 'HDFGroup/hdfview' && env.APPLE_CERTS_BASE64 != ''
       run: |
         echo "Code signing DMG installer..."
+        echo "Using identity: $SIGNER"
 
         # Determine DMG filename (snapshot includes commit SHA, release uses version only)
         if [ "${{ inputs.use_environ }}" = "snapshots" ]; then
@@ -1727,7 +1734,7 @@ jobs:
         codesign --force --timestamp --options runtime \
           --entitlements lib/macosx/distribution.entitlements \
           --verbose=4 --strict \
-          --sign "$MACOS_DEVELOPER_ID" \
+          --sign "$SIGNER" \
           --deep \
           "$DMG_FILE"
 


### PR DESCRIPTION
## Problem
The debug steps in the installer signing jobs were checking for old variable names that don't exist:
- macOS was checking `MACOS_CERTIFICATE` instead of `APPLE_CERTS_BASE64`
- Windows was checking `WINDOWS_CERTIFICATE` instead of `AZURE_TENANT_ID`

This caused misleading debug output showing secrets as "not set" even when they were properly configured.

## Solution
Updated both debug steps to check the actual variable names being used:

**macOS Debug (lines 1621-1631):**
- ✅ Check `APPLE_CERTS_BASE64` (was MACOS_CERTIFICATE)
- ✅ Check `KEYCHAIN_PASSWD` (was MACOS_DEVELOPER_ID)
- ✅ Check `APPLE_ID` (already correct)

**Windows Debug (lines 1886-1896):**
- ✅ Check `AZURE_TENANT_ID` (was WINDOWS_CERTIFICATE)
- ✅ Check `AZURE_ENDPOINT` (added for completeness)

## Verification
These variable names match:
- The job-level env declarations (lines 1582-1589 for macOS, 1802-1809 for Windows)
- The secret names in ant.yml (lines 34-51)
- The secrets passed from release.yml and daily-build.yml

## Testing
This PR is created from the canonical repository branch so the debug output will show the correct secret availability status when CI runs.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes incorrect variable names in macOS and Windows debug steps in `maven-build.yml` to ensure correct secret checks.
> 
>   - **Behavior**:
>     - Fixes variable name in macOS debug step to `APPLE_CERTS_BASE64` and `KEYCHAIN_PASSWD`.
>     - Fixes variable name in Windows debug step to `AZURE_TENANT_ID` and adds `AZURE_ENDPOINT`.
>   - **Verification**:
>     - Variable names now match job-level env declarations and secret names in `ant.yml`.
>   - **Testing**:
>     - Debug output will correctly show secret availability status when CI runs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 7393095594cb028f732b8db60ce9f500330c696d. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->