### PR TITLE
Fix macOS notarization to use correct variables from build.xml

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1747,9 +1747,11 @@ jobs:
         echo "DMG installer signed successfully"
 
     - name: Notarize DMG
-      if: github.repository == 'HDFGroup/hdfview' && env.APPLE_CERTS_BASE64 != ''
+      if: github.repository == 'HDFGroup/hdfview' && env.NOTARY_USER != ''
       run: |
         echo "Submitting DMG for notarization..."
+        echo "Using Apple ID: $NOTARY_USER"
+        echo "Using Team ID: $SIGNER"
 
         # Determine DMG filename (snapshot includes commit SHA, release uses version only)
         if [ "${{ inputs.use_environ }}" = "snapshots" ]; then
@@ -1760,12 +1762,14 @@ jobs:
 
         echo "Notarizing DMG: $DMG_FILE"
 
+        # Matching build.xml notarization (lines 1963-1968)
+        # Uses NOTARY_USER, NOTARY_KEY, and SIGNER (Team ID)
         xcrun notarytool submit \
           --wait \
           --output-format json \
-          --apple-id "$APPLE_ID" \
-          --password "$APPLE_ID_PASSWORD" \
-          --team-id "$APPLE_TEAM_ID" \
+          --apple-id "$NOTARY_USER" \
+          --password "$NOTARY_KEY" \
+          --team-id "$SIGNER" \
           "$DMG_FILE" > notarization-output.json
 
         # Check if notarization succeeded
@@ -1779,7 +1783,7 @@ jobs:
         echo "Notarization completed successfully"
 
     - name: Staple Notarization Ticket
-      if: github.repository == 'HDFGroup/hdfview' && env.APPLE_CERTS_BASE64 != ''
+      if: github.repository == 'HDFGroup/hdfview' && env.NOTARY_USER != ''
       run: |
         echo "Stapling notarization ticket to DMG..."
 


### PR DESCRIPTION
## Problem

After PR #430 was merged, macOS DMG signing works but notarization still fails with:
```
Error: Team ID must be at least 3 characters
```

The notarization step was using non-existent variables (`APPLE_ID`, `APPLE_ID_PASSWORD`, `APPLE_TEAM_ID`) that are all empty.

## Root Cause Analysis

By analyzing `build.xml` (lines 23, 28-29, 1963-1968), discovered the correct variable mapping:

**build.xml uses:**
```xml
<property name="sign.account" value="${env.SIGNER}" />
<property name="notarize.account" value="${env.NOTARY_USER}" />
<property name="notarize.keychain_key" value="${env.NOTARY_KEY}" />

<!-- Notarization command: -->
--apple-id ${notarize.account}           <!-- NOTARY_USER -->
--password ${notarize.keychain_key}      <!-- NOTARY_KEY -->
--team-id ${sign.account}                <!-- SIGNER -->
```

**Key Discovery:** The `SIGNER` variable serves dual purpose:
1. Code signing identity (Developer ID certificate name)
2. **Team ID for notarization** (e.g., "465P44SP96")

## Solution

Changed notarization to use the correct repository variables that are already configured and available:

**Before (wrong):**
```bash
--apple-id "$APPLE_ID"              # Empty - doesn't exist
--password "$APPLE_ID_PASSWORD"     # Empty - doesn't exist
--team-id "$APPLE_TEAM_ID"          # Empty - doesn't exist
```

**After (correct):**
```bash
--apple-id "$NOTARY_USER"           # thehdfgroup@hdfgroup.org
--password "$NOTARY_KEY"            # xdfm-pjev-jiko-appd
--team-id "$SIGNER"                 # 465P44SP96 (Team ID)
```

Also updated step conditions:
- Changed from: `if: env.APPLE_CERTS_BASE64 != ''`
- Changed to: `if: env.NOTARY_USER != ''`

## Verification

This matches the working `ant.yml` workflow where:
- Repository variables (NOTARY_USER, NOTARY_KEY, SIGNER, KEYCHAIN_NAME) are already configured
- The Ant build delegates to build.xml which uses these exact variables
- Notarization works successfully

## Testing

PR is created from canonical repository branch so secrets/variables will be available for testing the notarization flow.

## Related PRs

- #428: Fixed Windows MSI signing
- #429: Fixed macOS keychain setup
- #430: Fixed debug checks and added repository variables to env
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes macOS DMG notarization in `maven-build.yml` by using correct environment variables and updating step conditions.
> 
>   - **Behavior**:
>     - Fixes macOS DMG notarization by using correct variables `NOTARY_USER`, `NOTARY_KEY`, and `SIGNER` in `maven-build.yml`.
>     - Updates condition for notarization and stapling steps to `env.NOTARY_USER != ''`.
>   - **Misc**:
>     - Adds debug logging for Apple ID and Team ID during notarization in `maven-build.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 87b8e0c84f3dd537c51f918874c0907f9e7e56f5. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->