### PR TITLE
Add detailed notarization error logs from Apple

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1774,13 +1774,31 @@ jobs:
 
         # Check if notarization succeeded
         STATUS=$(jq -r '.status' notarization-output.json)
+        SUBMISSION_ID=$(jq -r '.id' notarization-output.json)
+
         if [ "$STATUS" != "Accepted" ]; then
-          echo "Notarization failed with status: $STATUS"
+          echo "❌ Notarization failed with status: $STATUS"
+          echo "Submission ID: $SUBMISSION_ID"
+          echo ""
+          echo "=== Notarization Response ==="
           jq '.' notarization-output.json
+          echo ""
+          echo "=== Fetching Detailed Logs from Apple ==="
+
+          # Get detailed logs from Apple (matching build.xml lines 1986-1996)
+          xcrun notarytool log \
+            --apple-id "$NOTARY_USER" \
+            --password "$NOTARY_KEY" \
+            --team-id "$SIGNER" \
+            "$SUBMISSION_ID" notarization-log.json
+
+          echo "=== Apple Notarization Logs ==="
+          cat notarization-log.json | jq '.'
+
           exit 1
         fi
 
-        echo "Notarization completed successfully"
+        echo "✅ Notarization completed successfully"
 
     - name: Staple Notarization Ticket
       if: github.repository == 'HDFGroup/hdfview' && env.NOTARY_USER != ''


### PR DESCRIPTION
## Problem

After PR #431 was merged, notarization is being submitted correctly but Apple rejects it with `Invalid` status:

```json
{
  "id": "00099826-c985-4218-b093-020b36578e82",
  "status": "Invalid",
  "message": "Processing complete"
}
```

We need to see Apple's detailed error logs to understand what's wrong with the DMG.

## Solution

Added detailed error logging using `xcrun notarytool log` command to fetch comprehensive diagnostics from Apple when notarization fails.

**When notarization fails, the workflow will now:**
1. Extract the submission ID from the response
2. Call `notarytool log` to retrieve Apple's detailed logs
3. Display the complete error information with proper formatting

**This will reveal specific issues such as:**
- Code signing validation errors
- Hardened runtime requirement violations
- Missing or invalid entitlements
- Bundle structure problems
- Timestamp validation failures
- Gatekeeper policy violations

## Implementation Details

Matches the build.xml approach (lines 1986-1996) for fetching notarization logs:

```bash
xcrun notarytool log \
  --apple-id "$NOTARY_USER" \
  --password "$NOTARY_KEY" \
  --team-id "$SIGNER" \
  "$SUBMISSION_ID" notarization-log.json
```

## Expected Outcome

The next CI run will show detailed logs from Apple that explain exactly why the DMG is being rejected, allowing us to identify and fix the specific issue (likely related to DMG code signing, entitlements, or hardened runtime configuration).

## Related PRs

- #428: Fixed Windows MSI signing
- #429: Fixed macOS keychain setup
- #430: Fixed debug checks and added repository variables
- #431: Fixed notarization to use correct variables (NOTARY_USER, NOTARY_KEY, SIGNER)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds detailed error logging for notarization failures in `maven-build.yml` using `xcrun notarytool log` to fetch Apple's logs.
> 
>   - **Behavior**:
>     - Adds detailed error logging for notarization failures in `maven-build.yml` using `xcrun notarytool log`.
>     - Fetches and displays Apple's detailed logs when notarization fails, including code signing errors, runtime violations, and more.
>   - **Implementation**:
>     - Extracts `SUBMISSION_ID` from `notarization-output.json` and uses it to retrieve logs.
>     - Logs are fetched and displayed in the notarization step of the macOS build process.
>   - **Misc**:
>     - Adds formatted output for notarization status and logs in `maven-build.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 03044fc58043531d3b6ec17ddd77216b96c3b0d2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->