### PR TITLE
Sign dylibs during jpackage app-image creation (fixes notarization)

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1087,6 +1087,14 @@ jobs:
     name: Build macOS Binary
     runs-on: macos-latest
     timeout-minutes: 30
+    env:
+      # Repository variables for signing (matching ant.yml)
+      KEYCHAIN_NAME: ${{ vars.KEYCHAIN_NAME }}
+      SIGNER: ${{ vars.SIGNER }}
+      # Secrets for keychain setup
+      APPLE_CERTS_BASE64: ${{ secrets.APPLE_CERTS_BASE64 }}
+      APPLE_CERTS_BASE64_PASSWD: ${{ secrets.APPLE_CERTS_BASE64_PASSWD }}
+      KEYCHAIN_PASSWD: ${{ secrets.KEYCHAIN_PASSWD }}
 
     steps:
     - name: Checkout Code
@@ -1489,22 +1497,78 @@ jobs:
         # Package application
         mvn package -DskipTests -B
 
-    - name: Create jpackage App Image
+    - name: Setup Keychain for Code Signing
+      if: github.repository == 'HDFGroup/hdfview' && env.APPLE_CERTS_BASE64 != ''
+      run: |
+        echo "Setting up temporary keychain for code signing..."
+
+        # Create variables (matching ant.yml and build.xml)
+        CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+        KEYCHAIN_FILE=$KEYCHAIN_NAME.keychain
+
+        # Import certificate from secrets
+        echo $APPLE_CERTS_BASE64 | base64 --decode > $CERTIFICATE_PATH
+
+        # Create and configure keychain
+        security -v create-keychain -p $KEYCHAIN_PASSWD $KEYCHAIN_FILE
+        security -v list-keychain -d user -s $KEYCHAIN_FILE
+        security -v list-keychains
+        security -v set-keychain-settings -lut 21600 $KEYCHAIN_FILE
+        security -v unlock-keychain -p $KEYCHAIN_PASSWD $KEYCHAIN_FILE
+
+        # Import certificate to keychain
+        security -v import $CERTIFICATE_PATH -P $APPLE_CERTS_BASE64_PASSWD -A -t cert -f pkcs12 -k $KEYCHAIN_FILE
+        security -v set-key-partition-list -S apple-tool:,codesign:,apple: -k $KEYCHAIN_PASSWD $KEYCHAIN_FILE
+
+        echo "✓ Keychain setup complete"
+        echo "✓ Code signing identity: $SIGNER"
+
+    - name: Prepare jpackage Input Directory
+      run: |
+        echo "Preparing jpackage input directory..."
+        # Use Maven antrun to prepare staging directory (no jpackage execution yet)
+        # This creates target/jpackage-input with all required files
+        mvn process-resources antrun:run@prepare-jpackage-input -Pjpackage-app-image -pl hdfview -B
+
+    - name: Create Signed jpackage App Image
       run: |
         echo "Creating distributable application package with jpackage..."
+        echo "Signing enabled: $([ -n \"$SIGNER\" ] && echo \"YES\" || echo \"NO\")"
 
-        # Create app-image using jpackage profile
-        # -pl object,hdfview: Build object and hdfview modules (skip repository)
-        # -Dmaven.test.skip=true: Skip test compilation and execution
-        # -Djacoco.skip=true: Skip JaCoCo (not needed for release builds)
-        # -Dpmd.skip=true: Skip PMD (static analysis not needed for release)
-        # -Ddependency-check.skip=true: Skip OWASP (runs in separate security workflow)
-        mvn verify -Pjpackage-app-image -pl object,hdfview \
-          -Dmaven.test.skip=true \
-          -Djacoco.skip=true \
-          -Dpmd.skip=true \
-          -Ddependency-check.skip=true \
-          -B
+        # Read version from VERSION file
+        HDFVIEW_VERSION=$(grep "^HDFVIEW_VERSION=" VERSION | cut -d'=' -f2)
+        echo "HDFView version: $HDFVIEW_VERSION"
+
+        # Build jpackage command
+        JPACKAGE_CMD="$JAVA_HOME/bin/jpackage --verbose \
+          --name HDFView \
+          --input hdfview/target/jpackage-input \
+          --main-jar hdfview-${HDFVIEW_VERSION}.jar \
+          --main-class hdf.view.HDFView \
+          --dest hdfview/target/dist \
+          --type app-image \
+          --app-version $HDFVIEW_VERSION \
+          --copyright 'Copyright 2006 by The HDF Group' \
+          --description 'A visual tool for browsing and editing HDF files' \
+          --vendor 'The HDF Group' \
+          --java-options -Xmx1024M \
+          --java-options -Djava.library.path=\$APPDIR \
+          --java-options -XstartOnFirstThread \
+          --arguments -Dhdfview.root=\$APPDIR"
+
+        # Add macOS signing arguments if signing is enabled (matching build.xml lines 2333-2341)
+        if [ -n "$SIGNER" ] && [ "$GITHUB_REPOSITORY" = "HDFGroup/hdfview" ]; then
+          echo "Adding macOS code signing arguments..."
+          JPACKAGE_CMD="$JPACKAGE_CMD \
+            --mac-sign \
+            --mac-package-identifier HDFView.hdfgroup.org \
+            --mac-package-signing-prefix org.hdfgroup.HDFView \
+            --mac-signing-key-user-name 'The HDF Group ($SIGNER)'"
+          echo "✓ Will sign all binaries with: The HDF Group ($SIGNER)"
+        fi
+
+        # Execute jpackage
+        eval $JPACKAGE_CMD
 
         echo "Verifying jpackage output..."
         if [ -d hdfview/target/dist/HDFView.app ]; then
@@ -1513,6 +1577,13 @@ jobs:
           echo "Native libraries: $(find hdfview/target/dist/HDFView.app/Contents -name "*.dylib" 2>/dev/null | wc -l) .dylib files"
           echo "JAR files: $(find hdfview/target/dist/HDFView.app/Contents -name "*.jar" 2>/dev/null | wc -l) JARs"
           echo "HDF5 plugins: $(ls -1 hdfview/target/dist/HDFView.app/Contents/app/plugin/*.dylib 2>/dev/null | wc -l) plugins"
+
+          # Verify code signatures if signing was enabled
+          if [ -n "$SIGNER" ] && [ "$GITHUB_REPOSITORY" = "HDFGroup/hdfview" ]; then
+            echo ""
+            echo "=== Verifying Code Signatures ==="
+            codesign -vvv --deep --strict HDFView.app 2>&1 | head -20
+          fi
         else
           echo "✗ jpackage app-image creation failed"
           exit 1
@@ -1661,25 +1732,17 @@ jobs:
 
         echo "Keychain setup complete"
 
-    - name: Sign App Bundle
+    - name: Verify App Bundle Signatures
       if: github.repository == 'HDFGroup/hdfview' && env.APPLE_CERTS_BASE64 != ''
       run: |
-        echo "Code signing app bundle..."
+        echo "Verifying app bundle signatures (signed during jpackage creation)..."
         echo "Using identity: $SIGNER"
 
-        # Sign the app bundle
-        codesign --force --timestamp --options runtime \
-          --entitlements lib/macosx/distribution.entitlements \
-          --verbose=4 --strict \
-          --sign "$SIGNER" \
-          --deep \
-          HDFView.app
-
-        # Verify signature
+        # Verify signature (app bundle already signed by jpackage)
         codesign -dvv HDFView.app
-        codesign -vvvv --strict HDFView.app
+        codesign -vvvv --deep --strict HDFView.app
 
-        echo "App bundle signed successfully"
+        echo "✓ App bundle signatures verified successfully"
 
     - name: Create DMG Installer
       run: |


### PR DESCRIPTION
## Problem

PR #432 added detailed notarization logging which revealed the root cause of Apple's 'Invalid' status:

**All dylibs inside the app bundle are unsigned:**
```json
{
  "path": "HDFView-99.99.99.dmg/HDFView.app/Contents/app/libdf.dylib",
  "message": "The binary is not signed with a valid Developer ID certificate.",
  "architecture": "x86_64"
},
{
  "path": "HDFView-99.99.99.dmg/HDFView.app/Contents/app/libdf.dylib",
  "message": "The signature does not include a secure timestamp.",
  "architecture": "x86_64"
}
```

## Root Cause

**Current broken workflow:**
1. **build-macos job**: Creates app-image without signing
   ```bash
   mvn verify -Pjpackage-app-image  # No signing!
   ```
2. **build-macos-installer job**: Attempts manual signing later
   ```bash
   codesign --deep HDFView.app  # Doesn't work!
   ```

The `--deep` flag is deprecated and doesn't reliably sign nested binaries (dylibs, frameworks, etc.).

## Solution

Implemented the **build.xml approach** (lines 2333-2341) where jpackage signs ALL binaries during app-image creation.

### Changes Made

#### 1. Added Signing Environment to build-macos Job
```yaml
env:
  # Repository variables
  KEYCHAIN_NAME: ${{ vars.KEYCHAIN_NAME }}
  SIGNER: ${{ vars.SIGNER }}
  # Secrets for keychain
  APPLE_CERTS_BASE64: ${{ secrets.APPLE_CERTS_BASE64 }}
  APPLE_CERTS_BASE64_PASSWD: ${{ secrets.APPLE_CERTS_BASE64_PASSWD }}
  KEYCHAIN_PASSWD: ${{ secrets.KEYCHAIN_PASSWD }}
```

#### 2. Added Keychain Setup Before jpackage
Sets up temporary keychain with Developer ID certificate before creating app-image.

#### 3. Direct jpackage Call with Signing
Instead of using Maven profile (which doesn't support signing), call jpackage directly:

```bash
jpackage --verbose \
  --name HDFView \
  --input hdfview/target/jpackage-input \
  --main-jar hdfview-${HDFVIEW_VERSION}.jar \
  --type app-image \
  --mac-sign \  # KEY: Enables signing of all binaries
  --mac-signing-key-user-name 'The HDF Group ($SIGNER)' \
  --mac-package-signing-prefix org.hdfgroup.HDFView
```

**How `--mac-sign` works:**
- Signs ALL executables, dylibs, and frameworks
- Adds secure timestamps automatically
- Uses Developer ID certificate from keychain
- Applies hardened runtime flags

#### 4. Updated build-macos-installer Job
- **Before**: Tried to sign app bundle (didn't work)
- **After**: Verifies app bundle signatures (already signed by jpackage)
- Keeps keychain setup for DMG signing

## Expected Outcome

When jpackage creates the app-image with `--mac-sign`:
1. ✅ All dylibs signed with Developer ID certificate
2. ✅ All signatures include secure timestamps
3. ✅ Hardened runtime enabled
4. ✅ Notarization will pass

## Testing

This PR is created from canonical repository branch so secrets/variables will be available to test the complete signing flow.

## Related PRs

- #428: Fixed Windows MSI signing
- #429: Fixed macOS keychain setup  
- #430: Fixed debug checks and added repository variables
- #431: Fixed notarization to use correct variables (NOTARY_USER, NOTARY_KEY, SIGNER)
- #432: Added detailed notarization error logs (revealed this issue)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Signs all dylibs during jpackage app-image creation to ensure successful notarization by Apple.
> 
>   - **Behavior**:
>     - Signs all dylibs during jpackage app-image creation using `--mac-sign` option in `build-macos-app` job.
>     - Verifies signatures in `build-macos-installer` job, ensuring all binaries are signed.
>   - **Environment Setup**:
>     - Adds signing environment variables to `build-macos` job for keychain setup.
>     - Sets up temporary keychain with Developer ID certificate before jpackage execution.
>   - **Commands**:
>     - Replaces Maven profile execution with direct jpackage call including signing options.
>     - Uses `codesign` to verify app bundle signatures post-creation.
>   - **Expected Outcome**:
>     - All dylibs signed with Developer ID certificate, secure timestamps added, and hardened runtime enabled.
>     - Notarization expected to pass with these changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 52af7eb475f8fb32da12f7edf0579cb1c504446a. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->