### PR TITLE
Fix jpackage input directory preparation for macOS signing

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1547,19 +1547,44 @@ jobs:
       run: |
         echo "Preparing jpackage input directory manually..."
 
+        # Debug: Show what's available
+        echo "=== Available JAR files ==="
+        echo "In libs/:"
+        ls -lh libs/*.jar 2>/dev/null || echo "  No libs/ directory or no JARs"
+        echo "In hdfview/target/:"
+        ls -lh hdfview/target/*.jar 2>/dev/null || echo "  No JARs in hdfview/target/"
+        echo ""
+
         # Create staging directory
         JPACKAGE_INPUT=hdfview/target/jpackage-input
         rm -rf $JPACKAGE_INPUT
         mkdir -p $JPACKAGE_INPUT
 
-        # Copy main JAR (built to libs/ by maven-jar-plugin)
+        # Copy main JAR - try both locations
         echo "Copying main JAR..."
-        cp libs/hdfview-*.jar $JPACKAGE_INPUT/
-        ls -lh $JPACKAGE_INPUT/*.jar
+        if ls libs/hdfview-*.jar 1> /dev/null 2>&1; then
+          cp libs/hdfview-*.jar $JPACKAGE_INPUT/
+          echo "  Copied from libs/"
+        elif ls hdfview/target/hdfview-*.jar 1> /dev/null 2>&1; then
+          cp hdfview/target/hdfview-*.jar $JPACKAGE_INPUT/
+          echo "  Copied from hdfview/target/"
+        else
+          echo "  ERROR: hdfview JAR not found!"
+          exit 1
+        fi
 
         # Copy object module JAR
         echo "Copying object module JAR..."
-        cp libs/object-*.jar $JPACKAGE_INPUT/
+        if ls libs/object-*.jar 1> /dev/null 2>&1; then
+          cp libs/object-*.jar $JPACKAGE_INPUT/
+          echo "  Copied from libs/"
+        elif ls object/target/object-*.jar 1> /dev/null 2>&1; then
+          cp object/target/object-*.jar $JPACKAGE_INPUT/
+          echo "  Copied from object/target/"
+        else
+          echo "  ERROR: object JAR not found!"
+          exit 1
+        fi
 
         # Copy all dependencies from target/lib
         echo "Copying dependencies from target/lib..."


### PR DESCRIPTION
## Summary

Fixes the jpackage input directory preparation issue from PR #434.

## Problem

The previous approach tried to use Maven antrun plugin directly:
```bash
mvn antrun:run@prepare-jpackage-input
```

This didn't work because the execution wasn't running in the proper Maven lifecycle context.

## Solution

**Manually prepare the jpackage input directory** by explicitly copying files:

1. Added debugging to show where JARs are located
2. Check multiple possible locations for JARs:
   - `libs/` (maven-jar-plugin output)
   - `hdfview/target/` (default Maven output)
   - `object/target/` (default Maven output)
3. Fail early with clear error if JARs not found
4. Copy all required files (JARs, dylibs, plugins)
5. Dynamically determine main JAR filename

## Debugging Output

The new version shows:
```
=== Available JAR files ===
In libs/:
  [lists all JARs]
In hdfview/target/:
  [lists all JARs]

Copying main JAR...
  Copied from libs/
```

This will reveal exactly where the JARs are and why jpackage couldn't find them.

## Changes

- Commit `1026b6a9`: Initial fix with manual file copying
- Commit `32ef4ac4`: Added extensive debugging and fallback paths

## Testing

This PR is from canonical repository so it will test with actual signing secrets.

Related: PR #434 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes jpackage input directory preparation for macOS signing by replacing Maven antrun plugin with manual file copying and adds debugging output.
> 
>   - **Behavior**:
>     - Replaces Maven antrun plugin with manual file copying for jpackage input directory in `maven-build.yml`.
>     - Adds debugging output to list available JARs and verify file copying.
>     - Checks multiple locations for JARs and fails early if not found.
>     - Dynamically determines main JAR filename for jpackage.
>   - **File Changes**:
>     - Updates `maven-build.yml` to manually prepare jpackage input directory and handle macOS signing.
>     - Adds steps to verify and debug the jpackage process, including listing JARs and dylibs.
>   - **Testing**:
>     - Tests with actual signing secrets from the canonical repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 32ef4ac4521d6404fe77a03c5faa7f34c8aa8c4d. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->