### PR TITLE
Document macOS signing implementation and lessons learned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -304,8 +304,12 @@ The project uses automated GitHub Actions workflows for continuous integration a
   - License compliance checking (prohibits GPL/AGPL)
 
 - **`maven-build.yml`**: Cross-platform binary builds and Maven package publishing
-  - 6 build jobs (Linux, Windows, macOS binaries and app packages)
+  - 7 build jobs across 3 platforms:
+    - **Linux**: binary tar.gz, app-image, installers (DEB/RPM - planned)
+    - **Windows**: binary zip, app-image, MSI installer (signed)
+    - **macOS**: binary tar.gz, app-image + DMG installer (consolidated, signed)
   - Downloads HDF4/HDF5 from GitHub releases
+  - Code signing for Windows (Microsoft Trusted Signing) and macOS (Developer ID + Notarization)
   - Optional GitHub Packages publication (Maven registry)
   - Called by release.yml for comprehensive releases
 
@@ -371,7 +375,13 @@ Located in `scripts/`:
 - Migrated from Ant-based installer creation to Java 21's native jpackage
 - Native installers for all platforms: MSI (Windows), DMG (macOS), DEB/RPM (Linux)
 - Code signing implemented for Windows (Authenticode) and macOS (Developer ID + Notarization)
-- Split workflow: app-image creation → installer creation → signing
+- **macOS**: Single consolidated job - signs during app-image creation using `jpackage --mac-sign`
+  - Keychain setup matching ant.yml implementation
+  - Signs all binaries (dylibs, frameworks, executables) during jpackage execution
+  - Uses repository variables: SIGNER, KEYCHAIN_NAME, NOTARY_USER, NOTARY_KEY
+  - Manual jpackage input directory preparation for reliability
+  - Full notarization workflow: submit → wait → log errors → staple
+- **Windows**: Microsoft Trusted Signing with Azure Code Signing
 - Conditional signing (only on canonical repository with secrets)
 - Comprehensive documentation for signing process and secret configuration
 - See: `docs/Installer-Signing-Guide.md` and `.claude/dev-docs/jpackage-integration.md`


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the macOS signing implementation that was completed in PRs #434 and #435.

## Changes

### CLAUDE.md (Team Documentation)
- Updated Phase 2E status with macOS signing details
- Documented single consolidated job approach (build-macos-app creates both app-image and DMG)
- Added repository variables usage (SIGNER, NOTARY_USER, NOTARY_KEY, KEYCHAIN_NAME)
- Updated maven-build.yml job structure description (7 jobs total, macOS consolidated)

### docs/Installer-Signing-Guide.md (User Documentation)
- Updated macOS secrets/variables section with clear distinction between secrets and variables
- Replaced manual `codesign --deep` approach with `jpackage --mac-sign` during creation
- Added manual jpackage input directory preparation steps
- Updated notarization workflow with error logging and detailed status checking
- Added critical notes about signing during app-image creation (not post-processing)
- Verified all steps match the working implementation

### .claude/dev-docs/jpackage-integration.md (Development - not in git)
- Updated macOS section with PR #434/#435 implementation details
- Documented consolidated job structure and workflow
- Added detailed signing process with code snippets
- Added 10 lessons learned from macOS signing debugging:
  - Sign during jpackage, not after
  - Manual input directory preparation required
  - Repository variables vs secrets
  - Detailed notarization error logging essential
  - Single consolidated job simpler

## Testing

All documentation has been verified against the working implementation:
- ✅ PR #434 successfully merged (consolidated macOS job)
- ✅ PR #435 successfully merged (jpackage input directory fixes)
- ✅ macOS signing and notarization passes in production CI
- ✅ Documentation accurately reflects the implementation

## Related PRs

- #434 - Simplify macOS installer build with signed jpackage
- #435 - Fix jpackage input directory preparation for macOS signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR adds detailed documentation for macOS signing implementation, including updates to team and user guides, and verification against previous PRs and production CI.
> 
>   - **Documentation Updates**:
>     - `CLAUDE.md`: Updated Phase 2E status with macOS signing details, consolidated job approach, and repository variables usage.
>     - `docs/Installer-Signing-Guide.md`: Updated macOS secrets/variables, replaced manual `codesign` with `jpackage --mac-sign`, added notarization workflow details.
>   - **Development Documentation**:
>     - `.claude/dev-docs/jpackage-integration.md`: Added macOS signing implementation details, consolidated job structure, and lessons learned.
>   - **Verification**:
>     - Documentation verified against PRs #434 and #435 and production CI.
>     - macOS signing and notarization passes in production CI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 0a89454bdb4253282927c4218965a81a0253ac42. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->