### PR TITLE
Bottom-up mac binary signing

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1876,16 +1876,67 @@ jobs:
 
         security unlock-keychain -p $KEYCHAIN_PASSWD $KEYCHAIN_NAME.keychain
 
-        # Sign with force to overwrite any existing signatures
-        codesign --force --deep --sign "The HDF Group ($SIGNER)" \
+        # Bottom-up signing approach (required for notarization)
+        # Sign all dylibs first (including HDF4/HDF5 libraries)
+        echo "Signing all dylib files..."
+        find universal/HDFView.app -name "*.dylib" -type f | while read dylib; do
+          echo "  Signing: $dylib"
+          codesign --force --sign "The HDF Group ($SIGNER)" \
+            --options runtime \
+            --timestamp \
+            "$dylib" || echo "  Warning: Failed to sign $dylib"
+        done
+
+        # Sign all framework bundles
+        echo "Signing frameworks..."
+        find universal/HDFView.app/Contents/runtime -name "*.framework" -type d | while read framework; do
+          echo "  Signing: $framework"
+          codesign --force --sign "The HDF Group ($SIGNER)" \
+            --options runtime \
+            --timestamp \
+            "$framework" || echo "  Warning: Failed to sign $framework"
+        done
+
+        # Sign executables in MacOS directory
+        echo "Signing executables..."
+        find universal/HDFView.app/Contents/MacOS -type f -perm +111 | while read exe; do
+          echo "  Signing: $exe"
+          codesign --force --sign "The HDF Group ($SIGNER)" \
+            --options runtime \
+            --timestamp \
+            "$exe" || echo "  Warning: Failed to sign $exe"
+        done
+
+        # Sign Java runtime executables
+        if [ -d universal/HDFView.app/Contents/runtime/Contents/Home/bin ]; then
+          echo "Signing JRE binaries..."
+          find universal/HDFView.app/Contents/runtime/Contents/Home/bin -type f -perm +111 | while read exe; do
+            echo "  Signing: $exe"
+            codesign --force --sign "The HDF Group ($SIGNER)" \
+              --options runtime \
+              --timestamp \
+              "$exe" || echo "  Warning: Failed to sign $exe"
+          done
+        fi
+
+        # Finally, sign the app bundle itself (WITHOUT --deep)
+        echo "Signing main app bundle..."
+        codesign --force --sign "The HDF Group ($SIGNER)" \
           --options runtime \
           --timestamp \
           universal/HDFView.app
 
-        echo "✓ Universal app signed"
+        echo "✓ Universal app signed with bottom-up approach"
 
-        # Verify signature
-        codesign -vvv --deep --strict universal/HDFView.app
+        # Verify signature (without --deep)
+        echo "Verifying app signature..."
+        codesign -vvv --strict universal/HDFView.app
+
+        # Verify a sample dylib signature
+        if [ -f universal/HDFView.app/Contents/app/libdf.dylib ]; then
+          echo "Verifying sample dylib signature..."
+          codesign -vvv --strict universal/HDFView.app/Contents/app/libdf.dylib
+        fi
 
     - name: Create Universal App Archive
       run: |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Implements bottom-up signing for macOS binaries in `maven-build.yml`, signing individual components before the app bundle for notarization.
> 
>   - **Behavior**:
>     - Implements bottom-up signing for macOS binaries in `maven-build.yml`.
>     - Signs all `.dylib` files, frameworks, and executables individually before signing the app bundle.
>     - Verifies signatures of the app and a sample `.dylib`.
>   - **Signing Process**:
>     - Signs `.dylib` files in `universal/HDFView.app`.
>     - Signs frameworks in `universal/HDFView.app/Contents/runtime`.
>     - Signs executables in `universal/HDFView.app/Contents/MacOS`.
>     - Signs Java runtime executables if present.
>     - Signs the main app bundle without `--deep` option.
>   - **Verification**:
>     - Verifies the app signature without `--deep`.
>     - Verifies a sample `.dylib` signature if present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for cd76960641554f9e268110bbd20d2e3d45472231. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->