### PR TITLE
Add file associations before signing mac binaries

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1476,9 +1476,14 @@ jobs:
           --type app-image \
           --app-version ${{ steps.get-version.outputs.HDFVIEW_VERSION }} \
           --mac-package-identifier HDFView.hdfgroup.org \
-          --mac-package-name HDFView-${{ steps.get-version.outputs.HDFVIEW_VERSION }}
+          --mac-package-name HDFView-${{ steps.get-version.outputs.HDFVIEW_VERSION }} \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF.properties \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewH4.properties \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF4.properties \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewH5.properties \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF5.properties
 
-        echo "✓ x86_64 app-image created"
+        echo "✓ x86_64 app-image created with file associations"
 
     - name: Create x86_64 Application Archive
       run: |
@@ -1722,9 +1727,14 @@ jobs:
           --type app-image \
           --app-version ${{ steps.get-version.outputs.HDFVIEW_VERSION }} \
           --mac-package-identifier HDFView.hdfgroup.org \
-          --mac-package-name HDFView-${{ steps.get-version.outputs.HDFVIEW_VERSION }}
+          --mac-package-name HDFView-${{ steps.get-version.outputs.HDFVIEW_VERSION }} \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF.properties \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewH4.properties \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF4.properties \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewH5.properties \
+          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF5.properties
 
-        echo "✓ ARM64 app-image created"
+        echo "✓ ARM64 app-image created with file associations"
 
     - name: Create ARM64 Application Archive
       run: |
@@ -1953,10 +1963,11 @@ jobs:
 
     - name: Create DMG Installer
       run: |
-        echo "Creating DMG installer from universal app-image..."
+        echo "Creating DMG installer from signed universal app-image..."
 
         cd universal
 
+        # Note: File associations already included in app-image (added before lipo merge)
         $JAVA_HOME/bin/jpackage \
           --type dmg \
           --app-image HDFView.app \
@@ -1964,11 +1975,6 @@ jobs:
           --app-version ${{ steps.get-version.outputs.HDFVIEW_VERSION }} \
           --mac-package-identifier HDFView.hdfgroup.org \
           --mac-package-name "HDFView-${{ steps.get-version.outputs.HDFVIEW_VERSION }}" \
-          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF.properties \
-          --file-associations ${{ github.workspace }}/package_files/HDFViewH4.properties \
-          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF4.properties \
-          --file-associations ${{ github.workspace }}/package_files/HDFViewH5.properties \
-          --file-associations ${{ github.workspace }}/package_files/HDFViewHDF5.properties \
           --dest .
 
         echo "DMG installer created"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add file associations to macOS app-image creation in `maven-build.yml` workflow for HDFView.
> 
>   - **macOS App-Image Creation**:
>     - Add file associations to `jpackage` command in `build-macos-app-x86_64` and `build-macos-app-arm64` jobs.
>     - File associations include `HDFViewHDF.properties`, `HDFViewH4.properties`, `HDFViewHDF4.properties`, `HDFViewH5.properties`, `HDFViewHDF5.properties`.
>   - **DMG Creation**:
>     - Update `Create DMG Installer` step to note file associations are included in app-image.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for bc04a793fbf00c833e6d1295ada52818c369a486. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->