### PR TITLE
Strip automatic signatures from mac binaries

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1801,6 +1801,18 @@ jobs:
         ls -la artifacts/x86_64/
         ls -la artifacts/arm64/
 
+    - name: Strip Ad-Hoc Signatures Before Merge
+      run: |
+        echo "Removing ad-hoc signatures from architecture-specific apps..."
+        echo "This is required because jpackage auto-signs with pseudo-identity '-'"
+        echo "and lipo invalidates those signatures when merging."
+
+        # Remove _CodeSignature directories from both apps
+        find artifacts/x86_64/HDFView.app -name "_CodeSignature" -type d -exec rm -rf {} + 2>/dev/null || true
+        find artifacts/arm64/HDFView.app -name "_CodeSignature" -type d -exec rm -rf {} + 2>/dev/null || true
+
+        echo "✓ Ad-hoc signatures stripped from both architecture builds"
+
     - name: Merge Binaries with lipo to Create Universal App
       run: |
         echo "Creating universal binary by merging x86_64 and ARM64..."
@@ -2108,6 +2120,7 @@ jobs:
           --name HDFView \
           --app-version "$VERSION" \
           --icon package_files/hdfview.png \
+          --linux-package-name hdfview \
           --linux-menu-group "Science" \
           --linux-shortcut \
           --file-associations package_files/HDFViewHDF.properties \
@@ -2134,6 +2147,7 @@ jobs:
           --name HDFView \
           --app-version "$VERSION" \
           --icon package_files/hdfview.png \
+          --linux-package-name hdfview \
           --linux-menu-group "Science" \
           --linux-shortcut \
           --file-associations package_files/HDFViewHDF.properties \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
       hdf5_artifact_basename: ${{ needs.determine-version.outputs.build_type == 'snapshot' && needs.get-base-names.outputs.hdf5_artifact_basename || needs.determine-version.outputs.hdf5_artifact_basename }}
       hdf5_version: ${{ needs.determine-version.outputs.hdf5_version }}
       build_environment: release
-      publish_to_maven_registry: true
+      publish_to_maven_registry: ${{ needs.determine-version.outputs.build_type == 'snapshot' }}
     secrets:
       APPLE_CERTS_BASE64: ${{ secrets.APPLE_CERTS_BASE64 }}
       APPLE_CERTS_BASE64_PASSWD: ${{ secrets.APPLE_CERTS_BASE64_PASSWD }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Strip ad-hoc signatures from macOS binaries before merging and update Maven publish condition in workflows.
> 
>   - **Behavior**:
>     - Strip ad-hoc signatures from macOS binaries in `maven-build.yml` before merging with `lipo`.
>     - Update `release.yml` to conditionally publish to Maven registry only for snapshot builds.
>   - **Misc**:
>     - Add `--linux-package-name hdfview` to `jpackage` commands in `maven-build.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for c444c7f42c4bfb1a265788c4f95ca4968f59ed80. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->