### PR TITLE
Propagate secrets between build workflows

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -77,6 +77,7 @@ env:
 jobs:
   build-linux-artifacts:
     uses: ./.github/workflows/build-linux.yml
+    secrets: inherit
     with:
       artifact_basename: ${{ inputs.artifact_basename }}
       build_type: ${{ inputs.build_type }}
@@ -90,6 +91,7 @@ jobs:
 
   build-windows-artifacts:
     uses: ./.github/workflows/build-windows.yml
+    secrets: inherit
     with:
       artifact_basename: ${{ inputs.artifact_basename }}
       build_type: ${{ inputs.build_type }}
@@ -103,6 +105,7 @@ jobs:
 
   build-macos-artifacts:
     uses: ./.github/workflows/build-macos.yml
+    secrets: inherit
     with:
       artifact_basename: ${{ inputs.artifact_basename }}
       build_type: ${{ inputs.build_type }}
@@ -117,6 +120,7 @@ jobs:
   publish-packages:
     if: inputs.publish_to_maven_registry == true
     uses: ./.github/workflows/publish-maven-packages.yml
+    secrets: inherit
     with:
       artifact_basename: ${{ inputs.artifact_basename }}
       build_type: ${{ inputs.build_type }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `secrets: inherit` to jobs in `maven-build.yml` to propagate secrets for authentication.
> 
>   - **Secrets Propagation**:
>     - Add `secrets: inherit` to `build-linux-artifacts`, `build-windows-artifacts`, `build-macos-artifacts`, and `publish-packages` jobs in `maven-build.yml`.
>     - Ensures secrets are available in these jobs for authentication or sensitive operations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 622e29bfb915fa66d122748b3e171b14d1302138. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->