### PR TITLE
Propagate secrets from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,7 @@ jobs:
   call-workflow-maven-build:
     needs: [determine-version, get-base-names, call-workflow-tarball]
     uses: ./.github/workflows/maven-build.yml
+    secrets: inherit
     with:
       artifact_basename: ${{ needs.call-workflow-tarball.outputs.artifact_basename }}
       build_type: ${{ needs.determine-version.outputs.build_type }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `secrets: inherit` to `call-workflow-maven-build` job in `release.yml` for secret propagation.
> 
>   - **Workflow Changes**:
>     - Add `secrets: inherit` to `call-workflow-maven-build` job in `release.yml` to allow secret propagation from the calling workflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for cb983af805ff423f9f2c2cfd2854fafb72feeba2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->