### PR TITLE
Treat x86/arm mac releases separately in release-files.yml

### DIFF
--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -105,10 +105,16 @@ jobs:
               name: ${{ inputs.build_environment == 'snapshots' && format('{0}-win64-msi', steps.get-artifact-info.outputs.ARTIFACT_BASENAME) || format('HDFView-{0}-win64-msi', steps.get-artifact-info.outputs.VERSION) }}
               path: ${{ github.workspace }}
 
-      - name: Get macOS DMG installer
+      - name: Get macOS DMG installer (x86_64)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-              name: ${{ inputs.build_environment == 'snapshots' && format('{0}-macOS-dmg', steps.get-artifact-info.outputs.ARTIFACT_BASENAME) || format('HDFView-{0}-macOS-dmg', steps.get-artifact-info.outputs.VERSION) }}
+              name: ${{ inputs.build_environment == 'snapshots' && format('{0}-macOS-x86_64-dmg', steps.get-artifact-info.outputs.ARTIFACT_BASENAME) || format('HDFView-{0}-macOS-x86_64-dmg', steps.get-artifact-info.outputs.VERSION) }}
+              path: ${{ github.workspace }}
+
+      - name: Get macOS DMG installer (arm64)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+              name: ${{ inputs.build_environment == 'snapshots' && format('{0}-macOS-arm64-dmg', steps.get-artifact-info.outputs.ARTIFACT_BASENAME) || format('HDFView-{0}-macOS-arm64-dmg', steps.get-artifact-info.outputs.VERSION) }}
               path: ${{ github.workspace }}
 
       - name: Get DEB installer (Linux)
@@ -130,10 +136,16 @@ jobs:
               name: zip-win-vs2022-app-binary
               path: ${{ github.workspace }}
       
-      - name: Get published app binary (MacOS)
+      - name: Get published app binary (MacOS x86_64)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-              name: tgz-macos14_clang-app-binary
+              name: macos-app-x86_64
+              path: ${{ github.workspace }}
+
+      - name: Get published app binary (MacOS arm64)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+              name: macos-app-arm64
               path: ${{ github.workspace }}
       
       - name: Get published app binary (Linux)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Separate handling for macOS x86_64 and arm64 releases in `release-files.yml`, updating artifact download steps and naming conventions.
> 
>   - **Behavior**:
>     - Separate handling for macOS DMG installers for `x86_64` and `arm64` in `release-files.yml`.
>     - Adds steps to download `macOS-x86_64-dmg` and `macOS-arm64-dmg` artifacts.
>     - Updates artifact names for macOS binaries to `macos-app-x86_64` and `macos-app-arm64`.
>   - **Misc**:
>     - Updates artifact naming conventions in `release-files.yml` for clarity and architecture specificity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for bdd960d7408dc67fc9e717f6ef7e3348740e1cc3. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->