### PR TITLE
SHA256 handles both mac variants

### DIFF
--- a/.github/workflows/release-files.yml
+++ b/.github/workflows/release-files.yml
@@ -177,10 +177,12 @@ jobs:
           # Snapshots: {artifact_basename}.msi, Releases: HDFView-{VERSION}.msi
           if [ "${{ inputs.build_environment }}" = "snapshots" ]; then
             ls -lh ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.msi || echo "MSI not found!"
-            ls -lh ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.dmg || echo "DMG not found!"
+            ls -lh HDFView-x86_64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg || echo "x86_64 DMG not found!"
+            ls -lh HDFView-arm64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg || echo "arm64 DMG not found!"
           else
             ls -lh HDFView-${{ steps.get-artifact-info.outputs.VERSION }}.msi || echo "MSI not found!"
-            ls -lh HDFView-${{ steps.get-artifact-info.outputs.VERSION }}.dmg || echo "DMG not found!"
+            ls -lh HDFView-x86_64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg || echo "x86_64 DMG not found!"
+            ls -lh HDFView-arm64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg || echo "arm64 DMG not found!"
           fi
 
       - name: Create sha256 sums for files
@@ -193,14 +195,17 @@ jobs:
           # Snapshots: {artifact_basename}.msi/dmg, Releases: HDFView-{VERSION}.msi/dmg
           if [ "${{ inputs.build_environment }}" = "snapshots" ]; then
             sha256sum ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.msi >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
-            sha256sum ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.dmg >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
+            sha256sum HDFView-x86_64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
+            sha256sum HDFView-arm64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
           else
             sha256sum HDFView-${{ steps.get-artifact-info.outputs.VERSION }}.msi >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
-            sha256sum HDFView-${{ steps.get-artifact-info.outputs.VERSION }}.dmg >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
+            sha256sum HDFView-x86_64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
+            sha256sum HDFView-arm64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
           fi
           sha256sum ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-Linux-x86_64.tar.gz >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
           sha256sum ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-win64.zip >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
-          sha256sum ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-Darwin.tar.gz >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
+          sha256sum HDFView-x86_64.app.tar.gz >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
+          sha256sum HDFView-arm64.app.tar.gz >>${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
           sha256sum UsersGuide.tar.gz >> ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
           sha256sum UsersGuide.zip >> ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
 
@@ -236,10 +241,12 @@ jobs:
               *.deb
               *.rpm
               ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.msi
-              ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.dmg
+              HDFView-x86_64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg
+              HDFView-arm64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg
               ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-Linux-x86_64.tar.gz
               ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-win64.zip
-              ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-Darwin.tar.gz
+              HDFView-x86_64.app.tar.gz
+              HDFView-arm64.app.tar.gz
               ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
@@ -260,9 +267,11 @@ jobs:
               *.deb
               *.rpm
               HDFView-${{ steps.get-artifact-info.outputs.VERSION }}.msi
-              HDFView-${{ steps.get-artifact-info.outputs.VERSION }}.dmg
+              HDFView-x86_64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg
+              HDFView-arm64-${{ steps.get-artifact-info.outputs.VERSION }}.dmg
               ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-Linux-x86_64.tar.gz
               ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-win64.zip
-              ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}App-Darwin.tar.gz
+              HDFView-x86_64.app.tar.gz
+              HDFView-arm64.app.tar.gz
               ${{ steps.get-artifact-info.outputs.ARTIFACT_BASENAME }}.sha256sums.txt
               if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `release-files.yml` to handle both x86_64 and arm64 macOS DMG files in the release process.
> 
>   - **Behavior**:
>     - Update `release-files.yml` to handle both x86_64 and arm64 macOS DMG files.
>     - Modify file checks to include `HDFView-x86_64` and `HDFView-arm64` DMG files.
>     - Update SHA256 sum creation to include both macOS variants.
>   - **File Handling**:
>     - Ensure both macOS DMG variants are included in the release artifacts list for both snapshot and release builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 1b2521d8b57566da2a5e47e8af9e1c3e6453d57c. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->