### PR TITLE
Remove manual specification of linux package name

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -360,7 +360,6 @@ jobs:
                 --name HDFView \
                 --app-version "$VERSION" \
                 --icon package_files/hdfview.png \
-                --linux-package-name HDFView \
                 --linux-menu-group "Science" \
                 --linux-shortcut \
                 --file-associations package_files/HDFViewHDF.properties \
@@ -387,7 +386,6 @@ jobs:
                 --name HDFView \
                 --app-version "$VERSION" \
                 --icon package_files/hdfview.png \
-                --linux-package-name HDFView \
                 --linux-menu-group "Science" \
                 --linux-shortcut \
                 --file-associations package_files/HDFViewHDF.properties \


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `--linux-package-name` from `jpackage` commands in `build-linux.yml` to use default package naming.
> 
>   - **Behavior**:
>     - Removed `--linux-package-name HDFView` from `jpackage` commands in `build-linux.yml`.
>     - Relies on default package naming for DEB and RPM installers.
>   - **Misc**:
>     - Simplifies `jpackage` command by removing unnecessary specification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 51e7e660462b8fac3afd833b7c6caa0b3f9dafb2. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->