### PR TITLE
Fix bad array check stopping bitmask application

### DIFF
--- a/hdfview/src/main/java/hdf/view/Tools.java
+++ b/hdfview/src/main/java/hdf/view/Tools.java
@@ -49,20 +49,20 @@ import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
-
 import javax.imageio.ImageIO;
-
-import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Shell;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import hdf.object.Datatype;
 import hdf.object.FileFormat;
 import hdf.object.Group;
 import hdf.object.ScalarDS;
 import hdf.view.ViewProperties.BITMASK_OP;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 
 /**
  * The "Tools" class contains various tools for HDF files such as jpeg to HDF
@@ -2500,8 +2500,8 @@ public final class Tools {
     public static boolean applyBitmask(Object theData, BitSet theMask, ViewProperties.BITMASK_OP op)
     {
 
-        if (theData == null || !theData.getClass().isArray() ||
-            Array.getLength(theData) <= 0 || theMask == null)
+        if (theData == null || !theData.getClass().isArray() || Array.getLength(theData) <= 0 ||
+            theMask == null)
             return false;
 
         char nt      = '0';

--- a/hdfview/src/main/java/hdf/view/Tools.java
+++ b/hdfview/src/main/java/hdf/view/Tools.java
@@ -49,20 +49,20 @@ import java.util.BitSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
+
 import javax.imageio.ImageIO;
+
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import hdf.object.Datatype;
 import hdf.object.FileFormat;
 import hdf.object.Group;
 import hdf.object.ScalarDS;
 import hdf.view.ViewProperties.BITMASK_OP;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Shell;
 
 /**
  * The "Tools" class contains various tools for HDF files such as jpeg to HDF
@@ -2499,8 +2499,9 @@ public final class Tools {
      */
     public static boolean applyBitmask(Object theData, BitSet theMask, ViewProperties.BITMASK_OP op)
     {
-        if (theData == null || !(theData instanceof Array) ||
-            ((theData instanceof Array) && (Array.getLength(theData) <= 0)) || theMask == null)
+
+        if (theData == null || !theData.getClass().isArray() ||
+            Array.getLength(theData) <= 0 || theMask == null)
             return false;
 
         char nt      = '0';


### PR DESCRIPTION
`java.lang.reflect.Array` is a utility class, so instanceof Array was always false for every object. `getClass().isArray()` correctly identifies 'actual' Java arrays.

Fixes #465
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes array identification in `applyBitmask()` in `Tools.java` by using `getClass().isArray()` instead of `instanceof Array`.
> 
>   - **Bug Fix**:
>     - Corrects array check in `applyBitmask()` in `Tools.java` by replacing `instanceof Array` with `getClass().isArray()`.
>     - Ensures `applyBitmask()` can correctly identify and process Java arrays.
>   - **Issue**:
>     - Fixes #465.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 087113e1b3299c8c3b30f78d587c93756524dbaf. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->