### PR TITLE
Remove recent commit check from release workflow

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -3,12 +3,6 @@ name: hdfview daily build
 # Triggers the workflow on a schedule or on demand
 on:
   workflow_dispatch:
-    inputs:
-      use_ignore:
-        description: 'Ignore has_changes check'
-        type: string
-        required: false
-        default: check
   schedule:
     - cron: "7 0 * * *"
 
@@ -17,14 +11,34 @@ permissions:
   packages: write
 
 jobs:
+  check-for-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check-new-commits.outputs.has-new-commits }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check for changed source
+      id: check-new-commits
+      uses: adriangl/check-new-commits-action@v1
+      with:
+        seconds: 86400 # One day in seconds
+
+    - run: echo "You have ${{ steps.check-new-commits.outputs.new-commits-number }} new commit(s) ✅!"
+      if: ${{ steps.check-new-commits.outputs.has-new-commits == 'true' }}
+
+    - run: echo "No new commits in the last 24 hours."
+      if: ${{ steps.check-new-commits.outputs.has-new-commits != 'true' }}
+
   get-base-names:
+    needs: check-for-changes
+    if: ${{ needs.check-for-changes.outputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       hdf4-name: ${{ steps.gethdf4base.outputs.HDF4_NAME_BASE }}
       hdf5-name: ${{ steps.gethdf5base.outputs.HDF5_NAME_BASE }}
       hdfview-name: ${{ steps.gethdfviewbase.outputs.HDFVIEW_NAME_BASE }}
       has-previous-build: ${{ steps.check-last-file.outputs.EXISTS }}
-      run-ignore: ${{ steps.getinputs.outputs.INPUTS_IGNORE }}
 
     steps:
     - uses: actions/checkout@v4.1.7
@@ -81,18 +95,10 @@ jobs:
         echo "hdf4 base name is ${{ steps.gethdf4base.outputs.HDF4_NAME_BASE }}."
         echo "hdf5 base name is ${{ steps.gethdf5base.outputs.HDF5_NAME_BASE }}."
 
-    - name: Read inputs
-      id: getinputs
-      run: |
-        echo "INPUTS_IGNORE=${{ inputs.use_ignore }}" >> $GITHUB_OUTPUT
-
-    - run: echo "use_ignore is ${{ steps.getinputs.outputs.INPUTS_IGNORE }}."
-
   call-workflow-tarball:
     needs: get-base-names
     uses: ./.github/workflows/tarball.yml
     with:
-      use_ignore: ${{ needs.get-base-names.outputs.run-ignore }}
       build_environment: snapshot
 
   call-workflow-maven-build:
@@ -106,7 +112,6 @@ jobs:
       hdf5_release_tag: snapshot
       hdf5_artifact_basename: ${{ needs.get-base-names.outputs.hdf5-name }}
       build_environment: snapshot
-    if: ${{ ((needs.call-workflow-tarball.outputs.has_changes == 'true') || (needs.get-base-names.outputs.run-ignore == 'ignore')) }}
 
   call-workflow-release:
     needs: [get-base-names, call-workflow-tarball, call-workflow-maven-build]
@@ -119,13 +124,11 @@ jobs:
       file_sha: ${{ needs.call-workflow-tarball.outputs.file_sha }}
       release_version_tag: v99.99.99
       build_environment: snapshot
-    if: ${{ ((needs.call-workflow-tarball.outputs.has_changes == 'true') || (needs.get-base-names.outputs.run-ignore == 'ignore')) }}
 
   # Remove old snapshot artifacts from the GitHub release to prevent accumulation
   # Only runs if:
   #   1. There was a previous build (last-file.txt exists)
   #   2. The new build has a different base name (commit SHA changed)
-  #   3. The build succeeded or ignore flag is set
   call-workflow-remove:
     needs: [get-base-names, call-workflow-tarball, call-workflow-maven-build, call-workflow-release]
     permissions:
@@ -135,5 +138,5 @@ jobs:
       artifact_basename: ${{ needs.get-base-names.outputs.hdfview-name }}
       release_version_tag: v99.99.99
       build_environment: snapshot
-    if: ${{ needs.get-base-names.outputs.has-previous-build == 'true' && ((needs.call-workflow-tarball.outputs.has_changes == 'true') || (needs.get-base-names.outputs.run-ignore == 'ignore')) && (needs.get-base-names.outputs.hdfview-name != needs.call-workflow-tarball.outputs.artifact_basename) }}
+    if: ${{ needs.get-base-names.outputs.has-previous-build == 'true' && (needs.get-base-names.outputs.hdfview-name != needs.call-workflow-tarball.outputs.artifact_basename) }}
 

--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -4,20 +4,12 @@ name: hdfview tarball
 on:
   workflow_call:
     inputs:
-      use_ignore:
-        description: 'Ignore has_changes check'
-        type: string
-        required: false
-        default: check
       build_environment:
         description: 'Environment to locate files'
         type: string
         required: true
         default: snapshot
     outputs:
-      has_changes:
-        description: "Whether there were changes the previous day"
-        value: ${{ jobs.check_commits.outputs.has_changes }}
       source_base:
         description: "The common version name of the binaries"
         value: ${{ jobs.create_tarball.outputs.source_base }}
@@ -39,7 +31,6 @@ jobs:
     name: Check for recent commits
     runs-on: ubuntu-latest
     outputs:
-      has_changes: ${{ steps.check-new-commits.outputs.has-new-commits }}
       branch_ref: ${{ steps.get-branch-name.outputs.BRANCH_REF }}
       branch_sha: ${{ steps.get-branch-sha.outputs.BRANCH_SHA }}
     steps:
@@ -63,24 +54,13 @@ jobs:
         SHORT_SHA=$(echo "${{ env.GITHUB_WF_SHA }}" | cut -c1-7)
         echo "BRANCH_SHA=$SHORT_SHA" >> $GITHUB_OUTPUT
 
-    - name: Check for changed source
-      id: check-new-commits
-      uses: adriangl/check-new-commits-action@v1
-      with:
-        seconds: 86400 # One day in seconds
-        branch: '${{ steps.get-branch-name.outputs.branch_ref }}'
-      if: ${{ (inputs.build_environment == 'snapshot' && inputs.use_ignore == 'check') }}
-
-    - run: echo "You have ${{ steps.check-new-commits.outputs.new-commits-number }} new commit(s) in ${{ steps.get-branch-name.outputs.BRANCH_REF }} ✅!"
-      if: ${{ steps.check-new-commits.outputs.has-new-commits == 'true' }}
-
     - run: echo "Short commit sha is ${{ steps.get-branch-sha.outputs.BRANCH_SHA }}!"
 
   create_tarball:
     name: Create a source tarball
     runs-on: ubuntu-latest
     needs: check_commits
-    if: ${{ ((inputs.build_environment == 'snapshot') && ((needs.check_commits.outputs.has_changes == 'true') || (inputs.use_ignore == 'ignore'))) || (inputs.build_environment == 'release') || (inputs.build_environment == 'pre-release') }}
+    if: ${{ (inputs.build_environment == 'snapshot') || (inputs.build_environment == 'release') || (inputs.build_environment == 'pre-release') }}
     outputs:
       artifact_basename: ${{ steps.set-artifact-basename.outputs.ARTIFACT_BASENAME }}
       source_base: ${{ steps.version.outputs.TAG_VERSION }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove recent commit check from release workflow, simplifying build process in `daily-build.yml` and `tarball.yml`.
> 
>   - **Workflow Changes**:
>     - Removed `use_ignore` input and related conditions from `daily-build.yml` and `tarball.yml`.
>     - Eliminated recent commit check in `check-for-changes` job in `daily-build.yml`.
>     - Simplified `create_tarball` job condition in `tarball.yml` to always run for `snapshot`, `release`, or `pre-release` environments.
>   - **Behavior**:
>     - Builds now proceed without checking for recent commits, streamlining the workflow process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=HDFGroup%2Fhdfview&utm_source=github&utm_medium=referral)<sup> for 40966c75b8d47fd0ad47d47f6dbc71ccd1e27cbf. You can [customize](https://app.ellipsis.dev/HDFGroup/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->