### PR TITLE
Implement support for sequences of compound types

### DIFF
--- a/hdfview/src/main/java/hdf/view/TableView/DataDisplayConverterFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataDisplayConverterFactory.java
@@ -73,7 +73,15 @@ public class DataDisplayConverterFactory {
 
         dataFormatReference = dataObject;
 
-        HDFDisplayConverter converter = getDataDisplayConverter(dataObject.getDatatype());
+        Datatype dtype = dataObject.getDatatype();
+
+        // For VLEN(compound), use compound base type so CompoundDataDisplayConverter is created
+        if (dtype.isVLEN() && !dtype.isVarStr() && dtype.getDatatypeBase() != null &&
+            dtype.getDatatypeBase().isCompound()) {
+            dtype = dtype.getDatatypeBase();
+        }
+
+        HDFDisplayConverter converter = getDataDisplayConverter(dtype);
 
         return converter;
     }

--- a/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
@@ -74,7 +74,17 @@ public class DataProviderFactory {
 
         dataFormatReference = dataObject;
 
-        HDFDataProvider dataProvider = getDataProvider(dataObject.getDatatype(), dataBuf, dataTransposed);
+        Datatype dtype = dataObject.getDatatype();
+
+        // For VLEN(compound), use the compound base type so CompoundDataProvider is created.
+        // The VLEN aspect is handled in the read path (H5DreadVL), and each member's data
+        // is a String[] of brace-enclosed values.
+        if (dtype.isVLEN() && !dtype.isVarStr() && dtype.getDatatypeBase() != null &&
+            dtype.getDatatypeBase().isCompound()) {
+            dtype = dtype.getDatatypeBase();
+        }
+
+        HDFDataProvider dataProvider = getDataProvider(dtype, dataBuf, dataTransposed);
 
         return dataProvider;
     }

--- a/hdfview/src/main/java/hdf/view/TableView/DataValidatorFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataValidatorFactory.java
@@ -69,9 +69,17 @@ public class DataValidatorFactory {
 
         dataFormatReference = dataObject;
 
+        Datatype dtype = dataObject.getDatatype();
+
+        // For VLEN(compound), use compound base type so CompoundDataValidator is created
+        if (dtype.isVLEN() && !dtype.isVarStr() && dtype.getDatatypeBase() != null &&
+            dtype.getDatatypeBase().isCompound()) {
+            dtype = dtype.getDatatypeBase();
+        }
+
         HDFDataValidator validator = null;
         try {
-            validator = getDataValidator(dataObject.getDatatype());
+            validator = getDataValidator(dtype);
         }
         catch (Exception ex) {
             log.debug("getDataValidator(DataFormat): failed to retrieve a DataValidator: ", ex);

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
@@ -686,8 +686,8 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                 HashMap<Integer, Integer> baseIndexMap;
                 HashMap<Integer, Integer> relCmpdStartIndexMap;
 
-                CompoundDataFormat dataFormat  = (CompoundDataFormat)dataObject;
-                Datatype cmpdType              = dataObject.getDatatype();
+                CompoundDataFormat dataFormat = (CompoundDataFormat)dataObject;
+                Datatype cmpdType             = dataObject.getDatatype();
 
                 // Resolve VLEN(compound) to compound base type
                 if (cmpdType.isVLEN() && !cmpdType.isVarStr() && cmpdType.getDatatypeBase() != null &&

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
@@ -688,6 +688,13 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
 
                 CompoundDataFormat dataFormat  = (CompoundDataFormat)dataObject;
                 Datatype cmpdType              = dataObject.getDatatype();
+
+                // Resolve VLEN(compound) to compound base type
+                if (cmpdType.isVLEN() && !cmpdType.isVarStr() && cmpdType.getDatatypeBase() != null &&
+                    cmpdType.getDatatypeBase().isCompound()) {
+                    cmpdType = cmpdType.getDatatypeBase();
+                }
+
                 Datatype[] selectedMemberTypes = dataFormat.getSelectedMemberTypes();
                 List<Datatype> localSelectedTypes =
                     DataFactoryUtils.filterNonSelectedMembers(dataFormat, cmpdType);
@@ -831,7 +838,14 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
         {
             CompoundDataFormat dataFormat = (CompoundDataFormat)dataObject;
 
-            Datatype cmpdType            = dataObject.getDatatype();
+            Datatype cmpdType = dataObject.getDatatype();
+
+            // Resolve VLEN(compound) to the compound base type for display purposes
+            if (cmpdType.isVLEN() && !cmpdType.isVarStr() && cmpdType.getDatatypeBase() != null &&
+                cmpdType.getDatatypeBase().isCompound()) {
+                cmpdType = cmpdType.getDatatypeBase();
+            }
+
             List<Datatype> selectedTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, cmpdType);
             final List<String> datasetMemberNames = Arrays.asList(dataFormat.getSelectedMemberNames());
 
@@ -931,15 +945,18 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                                            memberTypes);
             }
             else if (curDtype.isVLEN() && !curDtype.isVarStr()) {
-                log.debug("recursiveColumnHeaderSetup: curDtype={} size={}", curDtype,
-                          curDtype.getDatatypeSize());
                 /*
-                 * TODO(HDFView) [2025-12]: Implement column header setup for variable-length compound
-                 * members. Currently empty - no column headers generated for non-string variable-length
-                 * fields. Blocked by lack of true variable-length support in core library. Related:
-                 * H5CompoundDS.java:946, H5CompoundAttr.java:873, H5Datatype.java:2774 for vlen core support.
-                 * Cannot implement until variable-length data reading is functional.
+                 * For VLEN of COMPOUND, peel off the VLEN wrapper and recurse with the
+                 * compound base type. Each cell displays the variable-length values as a
+                 * brace-enclosed list, so no column multiplication is needed.
                  */
+                Datatype baseType = curDtype.getDatatypeBase();
+                if (baseType != null && baseType.isCompound()) {
+                    if (memberTypes.isEmpty()) {
+                        memberTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, baseType);
+                    }
+                    recursiveColumnHeaderSetup(outColNames, dataFormat, baseType, memberNames, memberTypes);
+                }
             }
             else if (curDtype.isCompound()) {
                 ListIterator<String> localIt = memberNames.listIterator();

--- a/object/src/main/java/hdf/object/h5/H5CompoundDS.java
+++ b/object/src/main/java/hdf/object/h5/H5CompoundDS.java
@@ -16,6 +16,7 @@ package hdf.object.h5;
 
 import java.lang.reflect.Array;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
@@ -943,30 +944,15 @@ public class H5CompoundDS extends CompoundDS implements MetaDataContainer {
         }
         else if (cmpdType.isVLEN() && !cmpdType.isVarStr()) {
             /*
-             * TODO(HDFView) [2025-12]: Implement true variable-length type support for compound datasets.
-             * Currently returns "*UNSUPPORTED*" placeholder for non-string variable-length fields.
-             * Requires integration with HDF5 H5Tvlen_* APIs for proper memory management.
-             * Related: See H5CompoundAttr.java line 873, H5Datatype.java line 2774.
-             */
-            String[] errVal = new String[nSelPoints];
-            String errStr   = "*UNSUPPORTED*";
-
-            for (int j = 0; j < nSelPoints; j++)
-                errVal[j] = errStr;
-
-            /*
-             * Setup a fake data list.
+             * For VLEN of COMPOUND, peel off the VLEN wrapper and recurse with the compound
+             * base type. The actual VLEN reading is handled in readSingleCompoundMember(),
+             * which detects the VLEN wrapper via dsDatatype.isVLEN() and uses H5DreadVL.
              */
             Datatype baseType = cmpdType.getDatatypeBase();
-            while (baseType != null && !baseType.isCompound()) {
-                baseType = baseType.getDatatypeBase();
+            if (baseType != null && baseType.isCompound()) {
+                theData = compoundTypeIO(ioType, did, spaceIDs, nSelPoints, (H5Datatype)baseType, writeBuf,
+                                         globalMemberIndex);
             }
-
-            List<Object> fakeVlenData =
-                (List<Object>)H5Datatype.allocateArray((H5Datatype)baseType, nSelPoints);
-            fakeVlenData.add(errVal);
-
-            theData = fakeVlenData;
         }
         else if (cmpdType.isCompound()) {
             List<Object> memberDataList = null;
@@ -1216,6 +1202,43 @@ public class H5CompoundDS extends CompoundDS implements MetaDataContainer {
             }
 
             /*
+             * If the dataset's top-level type is VLEN, compTid will be VLEN(compound{member}).
+             * Use H5DreadVL with a separate buffer and convert to string representation,
+             * since each row can have a different number of variable-length elements.
+             */
+            if (dsDatatype.isVLEN()) {
+                try {
+                    log.trace(
+                        "readSingleCompoundMember(): VLEN compound H5DreadVL did={} compTid={} spaceIDs[0]={} spaceIDs[1]={}",
+                        dsetID, compTid,
+                        (spaceIDs[0] == HDF5Constants.H5P_DEFAULT) ? "H5P_DEFAULT" : spaceIDs[0],
+                        (spaceIDs[1] == HDF5Constants.H5P_DEFAULT) ? "H5P_DEFAULT" : spaceIDs[1]);
+
+                    @SuppressWarnings("rawtypes")
+                    ArrayList[] vlBuf = new ArrayList[nSelPoints];
+                    for (int j = 0; j < nSelPoints; j++)
+                        vlBuf[j] = new ArrayList<>();
+
+                    H5.H5DreadVL(dsetID, compTid, spaceIDs[0], spaceIDs[1], HDF5Constants.H5P_DEFAULT, vlBuf);
+
+                    memberData = convertVlenMemberToStrings(vlBuf, nSelPoints, memberType);
+                }
+                catch (HDF5DataFiltersException exfltr) {
+                    log.debug("readSingleCompoundMember(): VLEN read failure: ", exfltr);
+                    throw new Exception("Filter not available exception: " + exfltr.getMessage(), exfltr);
+                }
+                catch (Exception ex) {
+                    log.debug("readSingleCompoundMember(): VLEN read failure: ", ex);
+                    throw new Exception("failed to read VLEN compound member: " + ex.getMessage(), ex);
+                }
+                finally {
+                    dsDatatype.close(compTid);
+                }
+
+                return memberData;
+            }
+
+            /*
              * Actually read the data for this member now that everything has been setup.
              */
             try {
@@ -1318,6 +1341,52 @@ public class H5CompoundDS extends CompoundDS implements MetaDataContainer {
         }
 
         return memberData;
+    }
+
+    /*
+     * Converts VLEN data (ArrayList[]) returned by H5DreadVL into a String[] where each
+     * element is a brace-enclosed, comma-separated list of values for that row.
+     * E.g., for VLEN(compound{x:f64}) with row 0 having two records (1.0, 3.0),
+     * the result for row 0 would be "{1.0, 3.0}".
+     */
+    @SuppressWarnings("rawtypes")
+    private String[] convertVlenMemberToStrings(ArrayList[] vlBuf, int nSelPoints, H5Datatype memberType)
+    {
+        String[] result = new String[nSelPoints];
+        for (int j = 0; j < nSelPoints; j++) {
+            ArrayList vlElements = vlBuf[j];
+            StringBuilder sb     = new StringBuilder("{");
+
+            for (int k = 0; k < vlElements.size(); k++) {
+                if (k > 0)
+                    sb.append(", ");
+
+                Object elem = vlElements.get(k);
+                if (elem instanceof byte[]) {
+                    try {
+                        Object converted = convertByteMember(memberType, (byte[])elem);
+                        if (converted != null && converted.getClass().isArray() &&
+                            Array.getLength(converted) > 0) {
+                            sb.append(Array.get(converted, 0));
+                        }
+                        else {
+                            sb.append(converted);
+                        }
+                    }
+                    catch (Exception ex) {
+                        log.debug("convertVlenMemberToStrings(): byte conversion failure: ", ex);
+                        sb.append("*ERR*");
+                    }
+                }
+                else {
+                    sb.append(elem);
+                }
+            }
+
+            sb.append("}");
+            result[j] = sb.toString();
+        }
+        return result;
     }
 
     /*


### PR DESCRIPTION
Variable-length sequences of compound datatypes could not be read or dispalyed due to being unsupported in `compoundTypeIO()`. This manifested as displaying *ERROR* instead of real data, without providing any clear output to the user about the root cause.

This PR implements a read path for the VLEN branch in `compoundTypeIO`, following the same pattern as for an array of compounds. In order to be able to display in a typical fixed-size  table format, each cell displays all entries of a certain member in the vlen sequence as a string. e.g. If the datatype is a sequence of a cmpd type "coord" with fields 'lat' and 'long', there will be two distinct columns 'lat' and 'long'. Each row 'lat' column will contain all the 'lat' values for the sequence in that row, and the same is true for the 'long' cell in each row.