### PR TITLE
Fix files always being opened in SWMR read only

### DIFF
--- a/hdfview/src/main/java/hdf/view/ViewProperties.java
+++ b/hdfview/src/main/java/hdf/view/ViewProperties.java
@@ -1532,8 +1532,10 @@ public class ViewProperties extends PreferenceStore {
         setShowImageValue(getBoolean("image.showvalues"));
 
         propVal = getString("file.mode");
-        if (!isDefault("file.mode"))
+        if (!isDefault("file.mode")) {
             setReadOnly("r".equalsIgnoreCase(propVal));
+            setReadSWMR("rs".equalsIgnoreCase(propVal));
+        }
 
         setEarlyLib(getString("lib.lowversion"));
 


### PR DESCRIPTION
The load path for `ViewProperties.java` never calls `setReadSWMR()` to read the stored value of `isReadSWMR`, leading to files always being opened read-only with SWMR semantics.