### PR TITLE
Register default file formats on demand instead of at class init

### DIFF
--- a/object/src/main/java/hdf/object/FileFormat.java
+++ b/object/src/main/java/hdf/object/FileFormat.java
@@ -191,71 +191,86 @@ public abstract class FileFormat extends File {
      */
     protected boolean isReadOnly = false;
 
-    // By default, HDF4 and HDF5 file formats are added to the supported formats list.
-    static
+    /**
+     * The file formats that are registered on demand, as pairs of the key that identifies
+     * the format and the name of the class that implements it.
+     *
+     * These are registered by the first call to any of the methods that consult the list
+     * of supported formats, rather than by a static initializer.
+     */
+    private static final String[][] DEFAULT_FILE_FORMATS = {{FILE_TYPE_HDF4, "hdf.object.h4.H4File"},
+                                                            {FILE_TYPE_HDF5, "hdf.object.h5.H5File"},
+                                                            {FILE_TYPE_NC3, "hdf.object.nc2.NC2File"},
+                                                            {"FITS", "hdf.object.fits.FitsFile"}};
+
+    /**
+     * Flag indicating that registration of the default file formats has begun. Note that
+     * it does not indicate that registration has finished; see
+     * {@link #registerDefaultFileFormats()}.
+     */
+    private static boolean defaultFormatsRegistered = false;
+
+    /**
+     * Registers the default file formats, if that has not already been attempted.
+     *
+     * Registration is attempted once per JVM. Formats that fail to register are not
+     * retried.
+     *
+     * The lock is what keeps other threads from reading a partly registered list, so this
+     * method must stay synchronized on every call. Guarding the lock with a volatile read
+     * of defaultFormatsRegistered, as double checked locking would, would break it, since the flag is
+     * set before the formats are registered , and a second thread would
+     * take the flag for a finished list and look up a format that is not in it yet.
+     */
+    private static synchronized void registerDefaultFileFormats()
     {
-        // add HDF4 to default modules
-        if (FileFormat.getFileFormat(FILE_TYPE_HDF4) == null) {
-            try {
-                @SuppressWarnings("rawtypes")
-                Class fileclass       = Class.forName("hdf.object.h4.H4File");
-                FileFormat fileformat = (FileFormat)fileclass.newInstance();
-                if (fileformat != null) {
-                    FileFormat.addFileFormat(FILE_TYPE_HDF4, fileformat);
-                    log.debug("FILE_TYPE_HDF4 file format added");
-                }
-            }
-            catch (Exception err) {
-                log.debug("FILE_TYPE_HDF4 instance failure: ", err);
+        if (defaultFormatsRegistered)
+            return;
+
+        /*
+         * Set before registering rather than after. Instantiating a format runs subclass
+         * code that may call back into the accessors that call this method, and such a
+         * call must not start registration a second time. A monitor is reentrant, so the
+         * lock alone does not stop that.
+         */
+        defaultFormatsRegistered = true;
+
+        for (String[] defaultFormat : DEFAULT_FILE_FORMATS)
+            registerDefaultFileFormat(defaultFormat[0], defaultFormat[1]);
+    }
+
+    /**
+     * Registers a single default file format, ignoring one that cannot be loaded.
+     *
+     * A format whose implementing class or native library is missing is skipped, so that
+     * it does not keep the remaining formats from being registered.
+     *
+     * @param key
+     *            A string that identifies the FileFormat.
+     * @param className
+     *            The name of the class that implements the FileFormat.
+     */
+    private static void registerDefaultFileFormat(String key, String className)
+    {
+        if (FileList.containsKey(key))
+            return;
+
+        try {
+            Class<?> fileclass    = Class.forName(className);
+            FileFormat fileformat = (FileFormat)fileclass.getDeclaredConstructor().newInstance();
+            if (fileformat != null) {
+                FileList.put(key, fileformat);
+                log.debug("{} file format added", key);
             }
         }
-
-        // add HDF5 to default modules
-        if (FileFormat.getFileFormat(FILE_TYPE_HDF5) == null) {
-            try {
-                @SuppressWarnings("rawtypes")
-                Class fileclass       = Class.forName("hdf.object.h5.H5File");
-                FileFormat fileformat = (FileFormat)fileclass.newInstance();
-                if (fileformat != null) {
-                    FileFormat.addFileFormat(FILE_TYPE_HDF5, fileformat);
-                    log.debug("FILE_TYPE_HDF5 file format added");
-                }
-            }
-            catch (Exception err) {
-                log.debug("FILE_TYPE_HDF5 instance failure: ", err);
-            }
+        catch (LinkageError err) {
+            // A format whose class or native library will not link is a broken installation
+            // rather than a routine absence, so it is reported above debug level.
+            log.warn("{} file format unavailable, its class or library could not be linked: {}", key,
+                     err.toString());
         }
-
-        // add NetCDF to default modules
-        if (FileFormat.getFileFormat(FILE_TYPE_NC3) == null) {
-            try {
-                @SuppressWarnings("rawtypes")
-                Class fileclass       = Class.forName("hdf.object.nc2.NC2File");
-                FileFormat fileformat = (FileFormat)fileclass.newInstance();
-                if (fileformat != null) {
-                    FileFormat.addFileFormat(FILE_TYPE_NC3, fileformat);
-                    log.debug("NetCDF3 file format added");
-                }
-            }
-            catch (Exception err) {
-                log.debug("NetCDF3 instance failure: ", err);
-            }
-        }
-
-        // add FITS to default modules
-        if (FileFormat.getFileFormat("FITS") == null) {
-            try {
-                @SuppressWarnings("rawtypes")
-                Class fileclass       = Class.forName("hdf.object.fits.FitsFile");
-                FileFormat fileformat = (FileFormat)fileclass.newInstance();
-                if (fileformat != null) {
-                    FileFormat.addFileFormat("FITS", fileformat);
-                    log.debug("Fits file format added");
-                }
-            }
-            catch (Exception err) {
-                log.debug("FITS instance failure: ", err);
-            }
+        catch (Exception err) {
+            log.debug("{} instance failure: ", key, err);
         }
     }
 
@@ -338,6 +353,8 @@ public abstract class FileFormat extends File {
         if ((fileformat == null) || (key == null))
             return;
 
+        registerDefaultFileFormats();
+
         key = key.trim();
 
         if (!FileList.containsKey(key))
@@ -364,7 +381,11 @@ public abstract class FileFormat extends File {
      * @see #getFileFormats()
      * @see #removeFileFormat(String)
      */
-    public static final FileFormat getFileFormat(String key) { return FileList.get(key); }
+    public static final FileFormat getFileFormat(String key)
+    {
+        registerDefaultFileFormats();
+        return FileList.get(key);
+    }
 
     /**
      * Returns an Enumeration of keys for all supported formats.
@@ -381,6 +402,7 @@ public abstract class FileFormat extends File {
     @SuppressWarnings("rawtypes")
     public static final Enumeration getFileFormatKeys()
     {
+        registerDefaultFileFormats();
         return ((Hashtable)FileList).keys();
     }
 
@@ -402,6 +424,8 @@ public abstract class FileFormat extends File {
     @SuppressWarnings("rawtypes")
     public static final FileFormat[] getFileFormats()
     {
+        registerDefaultFileFormats();
+
         int n = FileList.size();
         if (n <= 0)
             return null;
@@ -435,7 +459,11 @@ public abstract class FileFormat extends File {
      * @see #getFileFormatKeys()
      * @see #getFileFormats()
      */
-    public static final FileFormat removeFileFormat(String key) { return FileList.remove(key); }
+    public static final FileFormat removeFileFormat(String key)
+    {
+        registerDefaultFileFormats();
+        return FileList.remove(key);
+    }
 
     /**
      * Adds file extension(s) to the list of file extensions for supported file
@@ -532,6 +560,8 @@ public abstract class FileFormat extends File {
 
         if (!(new File(filename)).exists())
             throw new IllegalArgumentException("File " + filename + " does not exist.");
+
+        registerDefaultFileFormats();
 
         FileFormat fileFormat  = null;
         FileFormat knownFormat = null;

--- a/object/src/test/java/object/FileFormatInitOrderTest.java
+++ b/object/src/test/java/object/FileFormatInitOrderTest.java
@@ -1,0 +1,126 @@
+package object;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The default file formats must all register regardless of which class of the FileFormat
+ * hierarchy the JVM initializes first.
+ *
+ * That order is only observable in a JVM that has not yet touched hdf.object, and other
+ * tests in this module load FileFormat long before this one runs, so the check is made in
+ * a child JVM.
+ */
+@Tag("unit")
+@Tag("fast")
+public class FileFormatInitOrderTest {
+    private static final long PROBE_TIMEOUT_SECONDS = 120;
+
+    /** Default constructor. */
+    public FileFormatInitOrderTest() {}
+
+    /**
+     * HDF4 must register even when H4File is the first class of the hierarchy to load.
+     *
+     * @throws Exception
+     *             If the child JVM cannot be launched.
+     */
+    @Test
+    public void testHDF4RegistersWhenH4FileLoadsFirst() throws Exception
+    {
+        ProbeResult result = runProbe();
+
+        /*
+         * Registering HDF4 needs no native library: H4File's static initializer only builds
+         * a logger, and its no-argument constructor reads compile-time constants. A probe
+         * that cannot answer therefore means the child JVM itself was set up wrong, which is
+         * a failure rather than a reason to skip the check.
+         */
+        if (result.exitCode == H4FirstLoadProbe.EXIT_PROBE_ERROR)
+            fail("Probe JVM could not run the check: " + result.output());
+
+        String resultLine = result.resultLine();
+        assertNotNull(resultLine, "Probe did not report a result: " + result.output());
+        assertEquals(H4FirstLoadProbe.RESULT_PREFIX + "true", resultLine,
+                     "HDF4 was not registered when H4File was loaded first: " + result.output());
+    }
+
+    private ProbeResult runProbe() throws Exception
+    {
+        List<String> command = new ArrayList<>();
+        command.add(new File(System.getProperty("java.home"), "bin/java").getAbsolutePath());
+        command.add("-cp");
+        command.add(System.getProperty("java.class.path"));
+
+        // Surefire supplies this from build.properties. The child needs it to load the
+        // native libraries the format classes bind to.
+        String libraryPath = System.getProperty("java.library.path");
+        if (libraryPath != null && !libraryPath.isEmpty())
+            command.add("-Djava.library.path=" + libraryPath);
+
+        command.add(H4FirstLoadProbe.class.getName());
+
+        // Merged into one stream, so that filling one pipe cannot block the child while
+        // this side is reading the other.
+        Process probe = new ProcessBuilder(command).redirectErrorStream(true).start();
+        probe.getOutputStream().close();
+
+        // Drained by another thread, so that a child that neither exits nor closes its
+        // output cannot outlast the timeout below.
+        CompletableFuture<String> output = CompletableFuture.supplyAsync(() -> {
+            try {
+                return new String(probe.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            }
+            catch (IOException err) {
+                return "<probe output could not be read: " + err + ">";
+            }
+        });
+
+        if (!probe.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            probe.destroyForcibly();
+            throw new IllegalStateException("Probe JVM did not exit within " + PROBE_TIMEOUT_SECONDS +
+                                            " seconds");
+        }
+
+        return new ProbeResult(probe.exitValue(), output.get(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+
+    private static final class ProbeResult {
+        private final int exitCode;
+        private final String output;
+
+        ProbeResult(int exitCode, String output)
+        {
+            this.exitCode = exitCode;
+            this.output   = output;
+        }
+
+        /**
+         * @return The line the probe reported its result on, or null if it reported none.
+         *         The child's logging shares this stream, so the line is searched for
+         *         rather than taken to be the whole of the output.
+         */
+        String resultLine()
+        {
+            for (String line : output.split("\\R")) {
+                if (line.startsWith(H4FirstLoadProbe.RESULT_PREFIX))
+                    return line.trim();
+            }
+            return null;
+        }
+
+        String output() { return "exit=" + exitCode + " output=[" + output + "]"; }
+    }
+}

--- a/object/src/test/java/object/H4FirstLoadProbe.java
+++ b/object/src/test/java/object/H4FirstLoadProbe.java
@@ -1,0 +1,49 @@
+package object;
+
+import hdf.object.FileFormat;
+
+/**
+ * The body of the child JVM launched by {@link FileFormatInitOrderTest}.
+ *
+ * The test must run in a JVM where nothing has touched hdf.object yet, so that
+ * hdf.object.h4.H4File is the first class of the hierarchy to be initialized and
+ * FileFormat is initialized as its superclass step.
+ *
+ * Results go to stdout so the parent can tell a registration failure from an
+ * environment that has no HDF libraries at all.
+ */
+public class H4FirstLoadProbe {
+    /** The line printed when the probe completes. */
+    public static final String RESULT_PREFIX = "HDF4_REGISTERED=";
+
+    /** The line printed when the probe cannot run to completion. */
+    public static final String ERROR_PREFIX = "PROBE_ERROR=";
+
+    /** Exit status used when the probe itself failed. */
+    public static final int EXIT_PROBE_ERROR = 2;
+
+    /** Default constructor. */
+    public H4FirstLoadProbe() {}
+
+    /**
+     * Initializes H4File first, then reports whether HDF4 ended up registered.
+     *
+     * @param args
+     *            Ignored.
+     */
+    public static void main(String[] args)
+    {
+        try {
+            // First touch of the hierarchy. Initializes H4File, which initializes FileFormat.
+            Class.forName("hdf.object.h4.H4File");
+        }
+        catch (Throwable err) {
+            System.out.println(ERROR_PREFIX + err);
+            System.exit(EXIT_PROBE_ERROR);
+        }
+
+        boolean registered = FileFormat.getFileFormat(FileFormat.FILE_TYPE_HDF4) != null;
+        System.out.println(RESULT_PREFIX + registered);
+        System.exit(registered ? 0 : 1);
+    }
+}


### PR DESCRIPTION
FileFormat's static initializer registered the default formats by instantiating each implementing class. Every implementing class is a subclass of FileFormat, so whenever a subclass was itself what triggered FileFormat's initialization, the JVM was already initializing that subclass on the same thread. Class.forName then returned immediately rather than waiting, and the instance was built from a class whose own static fields were still unassigned.

This specifically became an issue for H4File, though it could easily have happend to NC2File or FitsFile instead.

Registration now happens on the first call to a method that consults the list of supported formats. Those calls come from outside any class initialization, so Class.forName completes the subclass before the instance is built. The formats are also a table rather than four copies of the same block, and a format that fails to load no longer stops the ones after it.

Fixes #481