### PR TITLE
Fix display of nested/vlen compound and variable-length string array datasets

### DIFF
--- a/hdfview/src/main/java/hdf/view/TableView/DataDisplayConverterFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataDisplayConverterFactory.java
@@ -73,15 +73,9 @@ public class DataDisplayConverterFactory {
 
         dataFormatReference = dataObject;
 
-        Datatype dtype = dataObject.getDatatype();
-
-        // For VLEN(compound), use compound base type so CompoundDataDisplayConverter is created
-        if (dtype.isVLEN() && !dtype.isVarStr() && dtype.getDatatypeBase() != null &&
-            dtype.getDatatypeBase().isCompound()) {
-            dtype = dtype.getDatatypeBase();
-        }
-
-        HDFDisplayConverter converter = getDataDisplayConverter(dtype);
+        // A top-level vlen-of-compound is a single column; dispatch on the dataset's own
+        // datatype so getDataDisplayConverter(VLEN) makes a VlenDataDisplayConverter.
+        HDFDisplayConverter converter = getDataDisplayConverter(dataObject.getDatatype());
 
         return converter;
     }
@@ -331,9 +325,15 @@ public class DataDisplayConverterFactory {
                         Object curObject = cmpdList.get(i);
                         if (curObject instanceof List)
                             buffer.append(memberTypeConverters[i].canonicalToDisplayValue(curObject));
-                        else {
+                        else if (curObject != null && curObject.getClass().isArray()) {
+                            // Array-of-compound: the member is a column-array indexed by row.
                             Object dataArrayValue = Array.get(curObject, cellRowIdx);
                             buffer.append(memberTypeConverters[i].canonicalToDisplayValue(dataArrayValue));
+                        }
+                        else {
+                            // A single compound element (e.g. one element of a vlen-of-compound):
+                            // the member is already a scalar value, not a per-row column.
+                            buffer.append(memberTypeConverters[i].canonicalToDisplayValue(curObject));
                         }
                     }
                     buffer.append("}");

--- a/hdfview/src/main/java/hdf/view/TableView/DataDisplayConverterFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataDisplayConverterFactory.java
@@ -237,7 +237,7 @@ public class DataDisplayConverterFactory {
             CompoundDataFormat compoundFormat = (CompoundDataFormat)dataFormatReference;
 
             List<Datatype> localSelectedTypes =
-                DataFactoryUtils.filterNonSelectedMembers(compoundFormat, dtype);
+                DataFactoryUtils.filterNonSelectedMembers(compoundFormat, dtype, false);
 
             log.trace("setting up {} base HDFDisplayConverters", localSelectedTypes.size());
 
@@ -610,7 +610,14 @@ public class DataDisplayConverterFactory {
             try {
                 Object obj;
                 Object convertedValue;
-                int arrLen = Array.getLength(value);
+
+                // Column-expanded vlen cells hand us a single scalar; defer to base converter.
+                if (!value.getClass().isArray() && !(value instanceof List)) {
+                    buffer.append(baseTypeConverter.canonicalToDisplayValue(value));
+                    return buffer;
+                }
+
+                int arrLen = (value instanceof List) ? ((List<?>)value).size() : Array.getLength(value);
 
                 log.trace("canonicalToDisplayValue({}): array length={}", value, arrLen);
 
@@ -621,7 +628,7 @@ public class DataDisplayConverterFactory {
                     if (i > 0)
                         buffer.append(", ");
 
-                    obj = Array.get(value, i);
+                    obj = (value instanceof List) ? ((List<?>)value).get(i) : Array.get(value, i);
 
                     convertedValue = baseTypeConverter.canonicalToDisplayValue(obj);
 

--- a/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
@@ -246,8 +246,8 @@ public class DataFactoryUtils {
             else if (curType.isCompound()) {
                 List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, curType, false);
 
-                buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex,
-                                         curProviderIndex, depth + 1);
+                buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex, curProviderIndex,
+                                         depth + 1);
             }
             else if (curType.isVLEN() && !curType.isVarStr()) {
                 for (int j = 0; j < arrSize; j++)
@@ -367,8 +367,8 @@ public class DataFactoryUtils {
 
                 List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, curType, false);
 
-                buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex,
-                                            curStartIdx, depth + 1);
+                buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex, curStartIdx,
+                                            depth + 1);
             }
             else if (curType.isVLEN() && !curType.isVarStr()) {
                 for (int j = 0; j < arrSize; j++) {

--- a/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
@@ -474,10 +474,7 @@ public class DataFactoryUtils {
      * write path is not symmetric with the (recently expanded) display path,
      * so a single-cell edit cannot be reliably mapped back to storage.
      */
-    public static boolean isUnsafeForWrite(Datatype dtype)
-    {
-        return isUnsafe(dtype, false);
-    }
+    public static boolean isUnsafeForWrite(Datatype dtype) { return isUnsafe(dtype, false); }
 
     private static boolean isUnsafe(Datatype dtype, boolean insideCompound)
     {
@@ -489,8 +486,7 @@ public class DataFactoryUtils {
 
         if (dtype.isArray()) {
             Datatype base = dtype.getDatatypeBase();
-            if (base != null && (base.isCompound() || base.isArray()
-                                 || (base.isVLEN() && !base.isVarStr())))
+            if (base != null && (base.isCompound() || base.isArray() || (base.isVLEN() && !base.isVarStr())))
                 return true;
             return insideCompound;
         }

--- a/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
@@ -101,8 +101,8 @@ public class DataFactoryUtils {
      * Identity-keyed so structurally identical Datatypes at different positions can
      * carry different widths.
      */
-    public static IdentityHashMap<Datatype, Integer>
-    computeVlenMaxLens(List<Datatype> selectedTypes, Object dataValue)
+    public static IdentityHashMap<Datatype, Integer> computeVlenMaxLens(List<Datatype> selectedTypes,
+                                                                        Object dataValue)
     {
         IdentityHashMap<Datatype, Integer> out = new IdentityHashMap<>();
         if (!(dataValue instanceof List) || selectedTypes == null)
@@ -167,8 +167,7 @@ public class DataFactoryUtils {
      * against that list would spuriously remove every non-compound member.
      */
     public static List<Datatype> filterNonSelectedMembers(CompoundDataFormat dataFormat,
-                                                          final Datatype compoundType,
-                                                          boolean isTopLevel)
+                                                          final Datatype compoundType, boolean isTopLevel)
     {
         List<Datatype> selectedTypes = new ArrayList<>(compoundType.getCompoundMemberTypes());
         if (!isTopLevel)
@@ -313,8 +312,8 @@ public class DataFactoryUtils {
                  * Therefore, we repeat our mapping for these types n times.
                  */
                 for (int j = 0; j < arrSize; j++) {
-                    buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens,
-                                             curMapIndex, curProviderIndex, depth + 1);
+                    buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens, curMapIndex,
+                                             curProviderIndex, depth + 1);
                 }
             }
             else if (curType.isCompound()) {

--- a/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
@@ -13,14 +13,11 @@
 
 package hdf.view.TableView;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import hdf.object.CompoundDataFormat;
 import hdf.object.Datatype;
@@ -82,62 +79,6 @@ public class DataFactoryUtils {
             return 1;
         }
         return 1;
-    }
-
-    /**
-     * Column-expansion width for a vlen member, looked up by Datatype identity.
-     * Returns 1 for non-vlen types, varstr, or types not present in the map.
-     */
-    public static int getVlenExpansion(Map<Datatype, Integer> vlenMaxLens, Datatype dtype)
-    {
-        if (dtype == null || !dtype.isVLEN() || dtype.isVarStr() || vlenMaxLens == null)
-            return 1;
-        Integer n = vlenMaxLens.get(dtype);
-        return (n == null || n.intValue() < 1) ? 1 : n.intValue();
-    }
-
-    /**
-     * Walk just-read compound data and return the max vlen length per vlen member.
-     * Identity-keyed so structurally identical Datatypes at different positions can
-     * carry different widths.
-     */
-    public static IdentityHashMap<Datatype, Integer> computeVlenMaxLens(List<Datatype> selectedTypes,
-                                                                        Object dataValue)
-    {
-        IdentityHashMap<Datatype, Integer> out = new IdentityHashMap<>();
-        if (!(dataValue instanceof List) || selectedTypes == null)
-            return out;
-
-        List<?> cols = (List<?>)dataValue;
-        for (int i = 0; i < selectedTypes.size() && i < cols.size(); i++) {
-            Datatype t = selectedTypes.get(i);
-            if (t == null || !t.isVLEN() || t.isVarStr())
-                continue;
-
-            Object col = cols.get(i);
-            int max    = 0;
-            if (col instanceof ArrayList[]) {
-                for (ArrayList<?> row : (ArrayList[])col) {
-                    if (row != null && row.size() > max)
-                        max = row.size();
-                }
-            }
-            else if (col != null && col.getClass().isArray()) {
-                int len = Array.getLength(col);
-                for (int j = 0; j < len; j++) {
-                    Object row = Array.get(col, j);
-                    if (row instanceof ArrayList<?> al && al.size() > max)
-                        max = al.size();
-                    else if (row != null && row.getClass().isArray()) {
-                        int sz = Array.getLength(row);
-                        if (sz > max)
-                            max = sz;
-                    }
-                }
-            }
-            out.put(t, Integer.valueOf(max));
-        }
-        return out;
     }
 
     /**
@@ -208,23 +149,14 @@ public class DataFactoryUtils {
                                                              List<Datatype> localSelectedTypes)
         throws Exception
     {
-        Map<Datatype, Integer> vlenMaxLens;
-        try {
-            vlenMaxLens = computeVlenMaxLens(localSelectedTypes, dataFormat.getData());
-        }
-        catch (Exception ex) {
-            log.debug("buildIndexMaps(): vlen length scan failed, defaulting to 1 per vlen: ", ex);
-            vlenMaxLens = new IdentityHashMap<>();
-        }
-
         HashMap<Integer, Integer>[] maps  = new HashMap[2];
         maps[COL_TO_BASE_CLASS_MAP_INDEX] = new HashMap<>();
         maps[CMPD_START_IDX_MAP_INDEX]    = new HashMap<>();
 
         buildColIdxToProviderMap(maps[COL_TO_BASE_CLASS_MAP_INDEX], dataFormat, localSelectedTypes,
-                                 vlenMaxLens, new int[] {0}, new int[] {0}, 0);
+                                 new int[] {0}, new int[] {0}, 0);
         buildRelColIdxToStartIdxMap(maps[CMPD_START_IDX_MAP_INDEX], dataFormat, localSelectedTypes,
-                                    vlenMaxLens, new int[] {0}, new int[] {0}, 0);
+                                    new int[] {0}, new int[] {0}, 0);
 
         return maps;
     }
@@ -256,8 +188,7 @@ public class DataFactoryUtils {
      */
     private static void buildColIdxToProviderMap(HashMap<Integer, Integer> outMap,
                                                  CompoundDataFormat dataFormat,
-                                                 List<Datatype> localSelectedTypes,
-                                                 Map<Datatype, Integer> vlenMaxLens, int[] curMapIndex,
+                                                 List<Datatype> localSelectedTypes, int[] curMapIndex,
                                                  int[] curProviderIndex, int depth) throws Exception
     {
         for (int i = 0; i < localSelectedTypes.size(); i++) {
@@ -293,33 +224,29 @@ public class DataFactoryUtils {
                 }
                 log.trace("buildColIdxToStartIdxMap(): arrSize after base={}", arrSize);
             }
-            else if (curType.isVLEN() && !curType.isVarStr()) {
-                // Only a top-level vlen-of-compound expands into its inner compound's
-                // leaves; inner vlens contribute a single column.
-                arrSize       = getVlenExpansion(vlenMaxLens, curType);
-                Datatype base = curType.getDatatypeBase();
-                if (depth == 0 && base != null && base.isCompound())
-                    nestedCompoundType = base;
-            }
+            // A vlen member is always a single column rendered by VlenDataProvider as the
+            // whole sequence (a brace-string, recursing for nested compounds). A top-level
+            // vlen-of-compound is already peeled to its inner compound at the dataset level,
+            // so any vlen reaching here is a member - never expanded into per-element columns.
 
             if (nestedCompoundType != null) {
                 List<Datatype> cmpdSelectedTypes =
                     filterNonSelectedMembers(dataFormat, nestedCompoundType, false);
 
                 /*
-                 * For Array/Vlen of Compound types, we repeat the compound members n times,
-                 * where n is the number of array elements of variable-length elements.
-                 * Therefore, we repeat our mapping for these types n times.
+                 * For Array of Compound types, we repeat the compound members n times,
+                 * where n is the number of array elements. For a top-level
+                 * vlen-of-compound, arrSize is 1 (one column per inner member).
                  */
                 for (int j = 0; j < arrSize; j++) {
-                    buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens, curMapIndex,
+                    buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex,
                                              curProviderIndex, depth + 1);
                 }
             }
             else if (curType.isCompound()) {
                 List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, curType, false);
 
-                buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens, curMapIndex,
+                buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex,
                                          curProviderIndex, depth + 1);
             }
             else if (curType.isVLEN() && !curType.isVarStr()) {
@@ -378,8 +305,7 @@ public class DataFactoryUtils {
      */
     private static void buildRelColIdxToStartIdxMap(HashMap<Integer, Integer> outMap,
                                                     CompoundDataFormat dataFormat,
-                                                    List<Datatype> localSelectedTypes,
-                                                    Map<Datatype, Integer> vlenMaxLens, int[] curMapIndex,
+                                                    List<Datatype> localSelectedTypes, int[] curMapIndex,
                                                     int[] curStartIdx, int depth) throws Exception
     {
         for (int i = 0; i < localSelectedTypes.size(); i++) {
@@ -415,12 +341,8 @@ public class DataFactoryUtils {
                 }
                 log.trace("buildRelColIdxToStartIdxMap(): arrSize after base={}", arrSize);
             }
-            else if (curType.isVLEN() && !curType.isVarStr()) {
-                arrSize       = getVlenExpansion(vlenMaxLens, curType);
-                Datatype base = curType.getDatatypeBase();
-                if (depth == 0 && base != null && base.isCompound())
-                    nestedCompoundType = base;
-            }
+            // Single column per vlen member (see buildColIdxToProviderMap). No per-element
+            // expansion; top-level vlen-of-compound is already peeled at the dataset level.
 
             if (nestedCompoundType != null) {
                 List<Datatype> cmpdSelectedTypes =
@@ -435,8 +357,8 @@ public class DataFactoryUtils {
                     if (depth == 0)
                         curStartIdx[0] = curMapIndex[0];
 
-                    buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens,
-                                                curMapIndex, curStartIdx, depth + 1);
+                    buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex,
+                                                curStartIdx, depth + 1);
                 }
             }
             else if (curType.isCompound()) {
@@ -445,7 +367,7 @@ public class DataFactoryUtils {
 
                 List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, curType, false);
 
-                buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens, curMapIndex,
+                buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex,
                                             curStartIdx, depth + 1);
             }
             else if (curType.isVLEN() && !curType.isVarStr()) {

--- a/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
@@ -468,4 +468,46 @@ public class DataFactoryUtils {
             }
         }
     }
+
+    /**
+     * Return true when the datatype tree contains a construct whose table-view
+     * write path is not symmetric with the (recently expanded) display path,
+     * so a single-cell edit cannot be reliably mapped back to storage.
+     */
+    public static boolean isUnsafeForWrite(Datatype dtype)
+    {
+        return isUnsafe(dtype, false);
+    }
+
+    private static boolean isUnsafe(Datatype dtype, boolean insideCompound)
+    {
+        if (dtype == null)
+            return false;
+
+        if (dtype.isVLEN() && !dtype.isVarStr())
+            return true;
+
+        if (dtype.isArray()) {
+            Datatype base = dtype.getDatatypeBase();
+            if (base != null && (base.isCompound() || base.isArray()
+                                 || (base.isVLEN() && !base.isVarStr())))
+                return true;
+            return insideCompound;
+        }
+
+        if (dtype.isCompound()) {
+            if (insideCompound)
+                return true;
+            List<Datatype> members = dtype.getCompoundMemberTypes();
+            if (members != null) {
+                for (Datatype m : members) {
+                    if (isUnsafe(m, true))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
 }

--- a/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataFactoryUtils.java
@@ -13,11 +13,14 @@
 
 package hdf.view.TableView;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import hdf.object.CompoundDataFormat;
 import hdf.object.Datatype;
@@ -48,6 +51,96 @@ public class DataFactoryUtils {
     public static final int CMPD_START_IDX_MAP_INDEX = 1;
 
     /**
+     * Number of flat leaf names a Datatype contributes to the flat-name list
+     * produced by H5Datatype.extractCompoundInfo. The rules:
+     *   compound        - sum of children's counts (no header entry)
+     *   array(compound) - 1 header + sum of inner compound's children's counts
+     *   array(atomic)   - 1
+     *   vlen(any)       - 1 (header only; vlen recursion is disabled)
+     *   atomic, varstr  - 1
+     */
+    public static int countLeafNames(Datatype t)
+    {
+        if (t == null)
+            return 1;
+        if (t.isCompound()) {
+            int sum                 = 0;
+            List<Datatype> children = t.getCompoundMemberTypes();
+            if (children != null)
+                for (Datatype child : children)
+                    sum += countLeafNames(child);
+            return sum;
+        }
+        if (t.isArray()) {
+            Datatype base = t.getDatatypeBase();
+            if (base != null && base.isCompound()) {
+                int sum = 1;
+                for (Datatype child : base.getCompoundMemberTypes())
+                    sum += countLeafNames(child);
+                return sum;
+            }
+            return 1;
+        }
+        return 1;
+    }
+
+    /**
+     * Column-expansion width for a vlen member, looked up by Datatype identity.
+     * Returns 1 for non-vlen types, varstr, or types not present in the map.
+     */
+    public static int getVlenExpansion(Map<Datatype, Integer> vlenMaxLens, Datatype dtype)
+    {
+        if (dtype == null || !dtype.isVLEN() || dtype.isVarStr() || vlenMaxLens == null)
+            return 1;
+        Integer n = vlenMaxLens.get(dtype);
+        return (n == null || n.intValue() < 1) ? 1 : n.intValue();
+    }
+
+    /**
+     * Walk just-read compound data and return the max vlen length per vlen member.
+     * Identity-keyed so structurally identical Datatypes at different positions can
+     * carry different widths.
+     */
+    public static IdentityHashMap<Datatype, Integer>
+    computeVlenMaxLens(List<Datatype> selectedTypes, Object dataValue)
+    {
+        IdentityHashMap<Datatype, Integer> out = new IdentityHashMap<>();
+        if (!(dataValue instanceof List) || selectedTypes == null)
+            return out;
+
+        List<?> cols = (List<?>)dataValue;
+        for (int i = 0; i < selectedTypes.size() && i < cols.size(); i++) {
+            Datatype t = selectedTypes.get(i);
+            if (t == null || !t.isVLEN() || t.isVarStr())
+                continue;
+
+            Object col = cols.get(i);
+            int max    = 0;
+            if (col instanceof ArrayList[]) {
+                for (ArrayList<?> row : (ArrayList[])col) {
+                    if (row != null && row.size() > max)
+                        max = row.size();
+                }
+            }
+            else if (col != null && col.getClass().isArray()) {
+                int len = Array.getLength(col);
+                for (int j = 0; j < len; j++) {
+                    Object row = Array.get(col, j);
+                    if (row instanceof ArrayList<?> al && al.size() > max)
+                        max = al.size();
+                    else if (row != null && row.getClass().isArray()) {
+                        int sz = Array.getLength(row);
+                        if (sz > max)
+                            max = sz;
+                    }
+                }
+            }
+            out.put(t, Integer.valueOf(max));
+        }
+        return out;
+    }
+
+    /**
      * Given a CompoundDataFormat, as well as a compound datatype, removes the
      * non-selected datatypes from the List of datatypes inside the compound
      * datatype and returns that as a new List.
@@ -62,34 +155,36 @@ public class DataFactoryUtils {
     public static List<Datatype> filterNonSelectedMembers(CompoundDataFormat dataFormat,
                                                           final Datatype compoundType)
     {
+        return filterNonSelectedMembers(dataFormat, compoundType, true);
+    }
+
+    /**
+     * Variant of {@link #filterNonSelectedMembers(CompoundDataFormat, Datatype)} that
+     * skips the selected-member filter for inner (non-top-level) compounds.
+     *
+     * The dataset's flat selected-member list only enumerates top-level leaves; inner
+     * compound members can't be individually deselected. Filtering an inner compound
+     * against that list would spuriously remove every non-compound member.
+     */
+    public static List<Datatype> filterNonSelectedMembers(CompoundDataFormat dataFormat,
+                                                          final Datatype compoundType,
+                                                          boolean isTopLevel)
+    {
+        List<Datatype> selectedTypes = new ArrayList<>(compoundType.getCompoundMemberTypes());
+        if (!isTopLevel)
+            return selectedTypes;
+
         List<Datatype> allSelectedTypes = Arrays.asList(dataFormat.getSelectedMemberTypes());
         if (allSelectedTypes == null) {
             log.debug("filterNonSelectedMembers(): selected compound member datatype list is null");
             return null;
         }
 
-        /*
-         * Make sure to make a copy of the compound datatype's member list, as we will
-         * make modifications to the list when members aren't selected.
-         */
-        List<Datatype> selectedTypes = new ArrayList<>(compoundType.getCompoundMemberTypes());
-
-        /*
-         * Among the datatypes within this compound type, only keep the ones that are
-         * actually selected in the dataset.
-         */
         Iterator<Datatype> localIt = selectedTypes.iterator();
         while (localIt.hasNext()) {
             Datatype curType = localIt.next();
-
-            /*
-             * Since the passed in allSelectedMembers list is a flattened out datatype
-             * structure, we want to leave the nested compound Datatypes inside our local
-             * list of datatypes.
-             */
             if (curType.isCompound())
                 continue;
-
             if (!allSelectedTypes.contains(curType))
                 localIt.remove();
         }
@@ -114,14 +209,23 @@ public class DataFactoryUtils {
                                                              List<Datatype> localSelectedTypes)
         throws Exception
     {
+        Map<Datatype, Integer> vlenMaxLens;
+        try {
+            vlenMaxLens = computeVlenMaxLens(localSelectedTypes, dataFormat.getData());
+        }
+        catch (Exception ex) {
+            log.debug("buildIndexMaps(): vlen length scan failed, defaulting to 1 per vlen: ", ex);
+            vlenMaxLens = new IdentityHashMap<>();
+        }
+
         HashMap<Integer, Integer>[] maps  = new HashMap[2];
         maps[COL_TO_BASE_CLASS_MAP_INDEX] = new HashMap<>();
         maps[CMPD_START_IDX_MAP_INDEX]    = new HashMap<>();
 
         buildColIdxToProviderMap(maps[COL_TO_BASE_CLASS_MAP_INDEX], dataFormat, localSelectedTypes,
-                                 new int[] {0}, new int[] {0}, 0);
+                                 vlenMaxLens, new int[] {0}, new int[] {0}, 0);
         buildRelColIdxToStartIdxMap(maps[CMPD_START_IDX_MAP_INDEX], dataFormat, localSelectedTypes,
-                                    new int[] {0}, new int[] {0}, 0);
+                                    vlenMaxLens, new int[] {0}, new int[] {0}, 0);
 
         return maps;
     }
@@ -153,7 +257,8 @@ public class DataFactoryUtils {
      */
     private static void buildColIdxToProviderMap(HashMap<Integer, Integer> outMap,
                                                  CompoundDataFormat dataFormat,
-                                                 List<Datatype> localSelectedTypes, int[] curMapIndex,
+                                                 List<Datatype> localSelectedTypes,
+                                                 Map<Datatype, Integer> vlenMaxLens, int[] curMapIndex,
                                                  int[] curProviderIndex, int depth) throws Exception
     {
         for (int i = 0; i < localSelectedTypes.size(); i++) {
@@ -189,9 +294,18 @@ public class DataFactoryUtils {
                 }
                 log.trace("buildColIdxToStartIdxMap(): arrSize after base={}", arrSize);
             }
+            else if (curType.isVLEN() && !curType.isVarStr()) {
+                // Only a top-level vlen-of-compound expands into its inner compound's
+                // leaves; inner vlens contribute a single column.
+                arrSize       = getVlenExpansion(vlenMaxLens, curType);
+                Datatype base = curType.getDatatypeBase();
+                if (depth == 0 && base != null && base.isCompound())
+                    nestedCompoundType = base;
+            }
 
             if (nestedCompoundType != null) {
-                List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, nestedCompoundType);
+                List<Datatype> cmpdSelectedTypes =
+                    filterNonSelectedMembers(dataFormat, nestedCompoundType, false);
 
                 /*
                  * For Array/Vlen of Compound types, we repeat the compound members n times,
@@ -199,15 +313,19 @@ public class DataFactoryUtils {
                  * Therefore, we repeat our mapping for these types n times.
                  */
                 for (int j = 0; j < arrSize; j++) {
-                    buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex,
-                                             curProviderIndex, depth + 1);
+                    buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens,
+                                             curMapIndex, curProviderIndex, depth + 1);
                 }
             }
             else if (curType.isCompound()) {
-                List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, curType);
+                List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, curType, false);
 
-                buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex, curProviderIndex,
-                                         depth + 1);
+                buildColIdxToProviderMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens, curMapIndex,
+                                         curProviderIndex, depth + 1);
+            }
+            else if (curType.isVLEN() && !curType.isVarStr()) {
+                for (int j = 0; j < arrSize; j++)
+                    outMap.put(curMapIndex[0]++, curProviderIndex[0]);
             }
             else
                 outMap.put(curMapIndex[0]++, curProviderIndex[0]);
@@ -261,7 +379,8 @@ public class DataFactoryUtils {
      */
     private static void buildRelColIdxToStartIdxMap(HashMap<Integer, Integer> outMap,
                                                     CompoundDataFormat dataFormat,
-                                                    List<Datatype> localSelectedTypes, int[] curMapIndex,
+                                                    List<Datatype> localSelectedTypes,
+                                                    Map<Datatype, Integer> vlenMaxLens, int[] curMapIndex,
                                                     int[] curStartIdx, int depth) throws Exception
     {
         for (int i = 0; i < localSelectedTypes.size(); i++) {
@@ -297,9 +416,16 @@ public class DataFactoryUtils {
                 }
                 log.trace("buildRelColIdxToStartIdxMap(): arrSize after base={}", arrSize);
             }
+            else if (curType.isVLEN() && !curType.isVarStr()) {
+                arrSize       = getVlenExpansion(vlenMaxLens, curType);
+                Datatype base = curType.getDatatypeBase();
+                if (depth == 0 && base != null && base.isCompound())
+                    nestedCompoundType = base;
+            }
 
             if (nestedCompoundType != null) {
-                List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, nestedCompoundType);
+                List<Datatype> cmpdSelectedTypes =
+                    filterNonSelectedMembers(dataFormat, nestedCompoundType, false);
 
                 /*
                  * For Array/Vlen of Compound types, we repeat the compound members n times,
@@ -310,18 +436,28 @@ public class DataFactoryUtils {
                     if (depth == 0)
                         curStartIdx[0] = curMapIndex[0];
 
-                    buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex,
-                                                curStartIdx, depth + 1);
+                    buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens,
+                                                curMapIndex, curStartIdx, depth + 1);
                 }
             }
             else if (curType.isCompound()) {
                 if (depth == 0)
                     curStartIdx[0] = curMapIndex[0];
 
-                List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, curType);
+                List<Datatype> cmpdSelectedTypes = filterNonSelectedMembers(dataFormat, curType, false);
 
-                buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, curMapIndex, curStartIdx,
-                                            depth + 1);
+                buildRelColIdxToStartIdxMap(outMap, dataFormat, cmpdSelectedTypes, vlenMaxLens, curMapIndex,
+                                            curStartIdx, depth + 1);
+            }
+            else if (curType.isVLEN() && !curType.isVarStr()) {
+                for (int j = 0; j < arrSize; j++) {
+                    if (depth == 0) {
+                        outMap.put(curMapIndex[0], curMapIndex[0]);
+                        curMapIndex[0]++;
+                    }
+                    else
+                        outMap.put(curMapIndex[0]++, curStartIdx[0]);
+                }
             }
             else {
                 if (depth == 0) {

--- a/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
@@ -77,8 +77,7 @@ public class DataProviderFactory {
         // A top-level vlen-of-compound is a single column showing the whole sequence, so
         // dispatch on the dataset's own datatype: getDataProvider(VLEN) makes a
         // VlenDataProvider (read path supplies one bare ArrayList[] of nested-List elements).
-        HDFDataProvider dataProvider =
-            getDataProvider(dataObject.getDatatype(), dataBuf, dataTransposed);
+        HDFDataProvider dataProvider = getDataProvider(dataObject.getDatatype(), dataBuf, dataTransposed);
 
         return dataProvider;
     }

--- a/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
@@ -74,17 +74,11 @@ public class DataProviderFactory {
 
         dataFormatReference = dataObject;
 
-        Datatype dtype = dataObject.getDatatype();
-
-        // For VLEN(compound), use the compound base type so CompoundDataProvider is created.
-        // The VLEN aspect is handled in the read path (H5DreadVL), and each member's data
-        // is a String[] of brace-enclosed values.
-        if (dtype.isVLEN() && !dtype.isVarStr() && dtype.getDatatypeBase() != null &&
-            dtype.getDatatypeBase().isCompound()) {
-            dtype = dtype.getDatatypeBase();
-        }
-
-        HDFDataProvider dataProvider = getDataProvider(dtype, dataBuf, dataTransposed);
+        // A top-level vlen-of-compound is a single column showing the whole sequence, so
+        // dispatch on the dataset's own datatype: getDataProvider(VLEN) makes a
+        // VlenDataProvider (read path supplies one bare ArrayList[] of nested-List elements).
+        HDFDataProvider dataProvider =
+            getDataProvider(dataObject.getDatatype(), dataBuf, dataTransposed);
 
         return dataProvider;
     }
@@ -798,19 +792,11 @@ public class DataProviderFactory {
                         theValue, rowIdx, adjustedColIndex);
                 }
                 else if (base instanceof VlenDataProvider) {
-                    // Walk back to the first column mapped to this vlen provider so the
-                    // offset within its column block is the cell's element index.
-                    int vlenStartIdx = columnIndex;
-                    while (vlenStartIdx > 0) {
-                        Integer prevProviderIdx = baseProviderIndexMap.get(vlenStartIdx - 1);
-                        if (prevProviderIdx == null || baseTypeProviders[prevProviderIdx] != base)
-                            break;
-                        vlenStartIdx--;
-                    }
-                    theValue = ((VlenDataProvider)base)
-                                   .getElementValue(colValue, rowIdx, columnIndex - vlenStartIdx);
-                    if (theValue == null)
-                        theValue = "";
+                    // A vlen member is a single column showing the whole sequence. Delegate
+                    // to the provider's full-sequence rendering (an array of per-element
+                    // values that the VlenDataDisplayConverter joins into a brace-string),
+                    // rather than fetching one element by column offset.
+                    theValue = base.getDataValue(colValue, fieldIdx, rowIdx);
                 }
                 else {
                     log.trace(
@@ -1496,20 +1482,16 @@ public class DataProviderFactory {
 
         private Object[] retrieveArrayOfCompoundElements(Object objBuf, int columnIndex, int rowIndex)
         {
-            long vlSize = Array.getLength(objBuf);
-            log.trace("retrieveArrayOfCompoundElements(): vlSize={}", vlSize);
-            long adjustedRowIdx =
-                (rowIndex * vlSize * colCount) +
-                (columnIndex / ((CompoundDataProvider)baseTypeDataProvider).baseProviderIndexMap.size());
-            long adjustedColIdx =
-                columnIndex % ((CompoundDataProvider)baseTypeDataProvider).baseProviderIndexMap.size();
-
             /*
-             * Since we flatten array of compound types, we only need to return a single
-             * value.
+             * A vlen-of-compound member is one column showing the whole sequence. The read
+             * path hands each row a list of compound elements already parsed into nested
+             * Lists (e.g. [[10, [11, 12]], [20, [21, 22]]]). Return the row's elements as an
+             * array; VlenDataDisplayConverter wraps them in [...] and the inner
+             * CompoundDataDisplayConverter renders each element as {...} (recursing for
+             * nested compounds).
              */
-            return new Object[] {
-                baseTypeDataProvider.getDataValue(objBuf, (int)adjustedColIdx, (int)adjustedRowIdx)};
+            ArrayList<?> vlElements = ((ArrayList[])objBuf)[rowIndex];
+            return vlElements.toArray();
         }
 
         private Object[] retrieveArrayOfArrayElements(Object objBuf, int columnIndex, int startRowIndex)

--- a/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
@@ -807,8 +807,8 @@ public class DataProviderFactory {
                             break;
                         vlenStartIdx--;
                     }
-                    theValue =
-                        ((VlenDataProvider)base).getElementValue(colValue, rowIdx, columnIndex - vlenStartIdx);
+                    theValue = ((VlenDataProvider)base)
+                                   .getElementValue(colValue, rowIdx, columnIndex - vlenStartIdx);
                     if (theValue == null)
                         theValue = "";
                 }

--- a/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
@@ -329,8 +329,11 @@ public class DataProviderFactory {
             try {
                 if (obj instanceof ArrayList)
                     theValue = ((ArrayList)obj).get(index);
-                else
+                else if (obj != null && obj.getClass().isArray())
                     theValue = Array.get(obj, index);
+                else
+                    // Scalar input: row dimension already resolved by the caller.
+                    theValue = obj;
             }
             catch (Exception ex) {
                 log.debug("getDataValue({}): failure: ", index, ex);
@@ -620,7 +623,7 @@ public class DataProviderFactory {
             selectedMemberOrders              = compoundFormat.getSelectedMemberOrders();
 
             List<Datatype> localSelectedTypes =
-                DataFactoryUtils.filterNonSelectedMembers(compoundFormat, dtype);
+                DataFactoryUtils.filterNonSelectedMembers(compoundFormat, dtype, false);
 
             log.trace("setting up {} base HDFDataProviders", localSelectedTypes.size());
 
@@ -793,6 +796,21 @@ public class DataProviderFactory {
                     log.trace(
                         "CompoundDataProvider.getDataValue: theValue={}, rowIdx={}, adjustedColIndex={}",
                         theValue, rowIdx, adjustedColIndex);
+                }
+                else if (base instanceof VlenDataProvider) {
+                    // Walk back to the first column mapped to this vlen provider so the
+                    // offset within its column block is the cell's element index.
+                    int vlenStartIdx = columnIndex;
+                    while (vlenStartIdx > 0) {
+                        Integer prevProviderIdx = baseProviderIndexMap.get(vlenStartIdx - 1);
+                        if (prevProviderIdx == null || baseTypeProviders[prevProviderIdx] != base)
+                            break;
+                        vlenStartIdx--;
+                    }
+                    theValue =
+                        ((VlenDataProvider)base).getElementValue(colValue, rowIdx, columnIndex - vlenStartIdx);
+                    if (theValue == null)
+                        theValue = "";
                 }
                 else {
                     log.trace(
@@ -1357,6 +1375,8 @@ public class DataProviderFactory {
         private static final Logger log = LoggerFactory.getLogger(VlenDataProvider.class);
 
         private final HDFDataProvider baseTypeDataProvider;
+        private final Datatype baseType;
+        private final int numInnerLeaves;
 
         private final StringBuilder buffer;
 
@@ -1367,10 +1387,10 @@ public class DataProviderFactory {
         {
             super(dtype, dataBuf, dataTransposed);
 
-            Datatype baseType = dtype.getDatatypeBase();
-            baseTypeClass     = baseType.getDatatypeClass();
-
+            baseType             = dtype.getDatatypeBase();
+            baseTypeClass        = baseType.getDatatypeClass();
             baseTypeDataProvider = getDataProvider(baseType, dataBuf, dataTransposed);
+            numInnerLeaves       = DataFactoryUtils.countLeafNames(baseType);
 
             buffer = new StringBuilder();
         }
@@ -1558,6 +1578,39 @@ public class DataProviderFactory {
                 tempArray[i] = baseTypeDataProvider.getDataValue(vlElements.toArray(), i);
 
             return tempArray;
+        }
+
+        /**
+         * Return one cell value from the row's vlen, given the cell's offset within
+         * the vlen's column block. The block is laid out element-major:
+         * {@code [elem0_leaf0, elem0_leaf1, ..., elem1_leaf0, ...]}. Returns null
+         * when the offset falls past the row's actual vlen length.
+         */
+        Object getElementValue(Object objBuf, int rowIdx, int elementIndex)
+        {
+            try {
+                ArrayList vlElements = ((ArrayList[])objBuf)[rowIdx];
+
+                if (baseTypeDataProvider instanceof CompoundDataProvider && numInnerLeaves > 0) {
+                    int vlenElemIdx = elementIndex / numInnerLeaves;
+                    int leafIdx     = elementIndex % numInnerLeaves;
+                    if (vlenElemIdx < 0 || vlenElemIdx >= vlElements.size())
+                        return null;
+                    return baseTypeDataProvider.getDataValue(vlElements.get(vlenElemIdx), leafIdx, 0);
+                }
+
+                if (elementIndex < 0 || elementIndex >= vlElements.size())
+                    return null;
+
+                Object elem = vlElements.get(elementIndex);
+                if (elem instanceof byte[])
+                    return baseTypeDataProvider.getDataValue(elem, 0);
+                return elem;
+            }
+            catch (Exception ex) {
+                log.debug("getElementValue(rowIdx={}, elementIndex={}): failure: ", rowIdx, elementIndex, ex);
+                return DataFactoryUtils.errStr;
+            }
         }
 
         @Override

--- a/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataProviderFactory.java
@@ -1089,12 +1089,68 @@ public class DataProviderFactory {
                 nCols = super.getColumnCount();
         }
 
+        /**
+         * Read element {@code i} of an array-or-List container, or null when out of range.
+         */
+        private static Object elementAt(Object container, int i)
+        {
+            if (container == null || i < 0)
+                return null;
+            if (container instanceof List) {
+                List<?> list = (List<?>)container;
+                return (i < list.size()) ? list.get(i) : null;
+            }
+            if (container.getClass().isArray())
+                return (i < Array.getLength(container)) ? Array.get(container, i) : null;
+            return null;
+        }
+
+        /**
+         * Produce this array's cell value from {@code container}, the java.util.List
+         * holding exactly this array's elements. Used when the data was read through
+         * translate_rbuf() (the JNI's documented buffer data model), which represents an
+         * ARRAY as an ArrayList of its elements rather than as a slice of one flat
+         * buffer. Because each level of nesting is its own List, the elements are
+         * addressed directly by index instead of by an accumulated flattened offset -
+         * the latter cannot describe a List-per-row layout once nesting is involved.
+         */
+        private Object getDataValueFromContainer(Object container, int columnIndex)
+        {
+            Object[] tempArray = new Object[(int)arraySize];
+
+            for (int i = 0; i < arraySize; i++) {
+                Object elem = elementAt(container, i);
+
+                if (baseTypeDataProvider instanceof ArrayDataProvider)
+                    tempArray[i] = ((ArrayDataProvider)baseTypeDataProvider)
+                                       .getDataValueFromContainer(elem, columnIndex);
+                else if (elem instanceof byte[])
+                    tempArray[i] = baseTypeDataProvider.getDataValue(elem, 0);
+                else
+                    tempArray[i] = elem;
+            }
+
+            return tempArray;
+        }
+
         @Override
         public Object getDataValue(int columnIndex, int rowIndex)
         {
             log.trace("getDataValue(rowIndex={}, columnIndex={}): start", rowIndex, columnIndex);
             try {
                 int bufIndex = physicalLocationToBufIndex(rowIndex, columnIndex);
+
+                /*
+                 * When the data was read through translate_rbuf(), each row slot holds a
+                 * java.util.List of this array's elements rather than a slice of one flat
+                 * buffer, so address the elements directly instead of by flattened offset.
+                 */
+                Object rowContainer = elementAt(dataBuf, bufIndex);
+                if (rowContainer instanceof List) {
+                    theValue = getDataValueFromContainer(rowContainer, columnIndex);
+                    log.trace("getDataValue({}, {})({}): finish", rowIndex, columnIndex, theValue);
+                    return theValue;
+                }
 
                 bufIndex *= arraySize;
 
@@ -1145,6 +1201,15 @@ public class DataProviderFactory {
         {
             log.trace("getDataValue(obj={} rowIndex={}, columnIndex={}): start", obj, rowIndex, columnIndex);
             try {
+                /* See getDataValue(int, int) - List-per-row layout is addressed directly. */
+                Object rowContainer = elementAt(obj, rowIndex);
+                if (rowContainer instanceof List) {
+                    theValue = getDataValueFromContainer(rowContainer, columnIndex);
+                    log.trace("getDataValue(obj={}, rowIndex={}, columnIndex={})=({}): finish", obj, rowIndex,
+                              columnIndex, theValue);
+                    return theValue;
+                }
+
                 long index = rowIndex * arraySize;
 
                 if (baseTypeDataProvider instanceof CompoundDataProvider) {

--- a/hdfview/src/main/java/hdf/view/TableView/DataValidatorFactory.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DataValidatorFactory.java
@@ -244,7 +244,7 @@ public class DataValidatorFactory {
             CompoundDataFormat compoundFormat = (CompoundDataFormat)dataFormatReference;
 
             List<Datatype> localSelectedTypes =
-                DataFactoryUtils.filterNonSelectedMembers(compoundFormat, dtype);
+                DataFactoryUtils.filterNonSelectedMembers(compoundFormat, dtype, false);
 
             log.trace("setting up {} base HDFDataValidators", localSelectedTypes.size());
 

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultBaseTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultBaseTableView.java
@@ -1311,15 +1311,15 @@ public abstract class DefaultBaseTableView implements TableView {
             return;
         lastUnsafeWriteNoticeMs = now;
 
-        Tools.showInformation(
-            shell, "Editing disabled",
-            "HDFView does not support editing datasets that contain any of the following:\n"
-                + "  - variable-length sequences (non-string)\n"
-                + "  - arrays of compound, array, or variable-length sequence\n"
-                + "  - arrays nested inside compound\n"
-                + "  - compounds nested inside compound\n\n"
-                + "Use a separate tool (h5py, the HDF5 C API, h5edit, etc.) to modify these "
-                + "datatypes.");
+        Tools.showInformation(shell, "Editing disabled",
+                              "HDFView does not support editing datasets that contain any of the following:\n"
+                                  + "  - variable-length sequences (non-string)\n"
+                                  + "  - arrays of compound, array, or variable-length sequence\n"
+                                  + "  - arrays nested inside compound\n"
+                                  + "  - compounds nested inside compound\n\n"
+                                  +
+                                  "Use a separate tool (h5py, the HDF5 C API, h5edit, etc.) to modify these "
+                                  + "datatypes.");
     }
 
     @Override
@@ -2608,15 +2608,14 @@ public abstract class DefaultBaseTableView implements TableView {
                                         showUnsafeWriteNotice();
                                     }
                                 });
-                            uiBindingRegistry.registerFirstKeyBinding(new LetterOrDigitKeyEventMatcher(),
-                                                                      new IKeyAction() {
-                                                                          @Override
-                                                                          public void run(NatTable table,
-                                                                                          KeyEvent event)
-                                                                          {
-                                                                              showUnsafeWriteNotice();
-                                                                          }
-                                                                      });
+                            uiBindingRegistry.registerFirstKeyBinding(
+                                new LetterOrDigitKeyEventMatcher(), new IKeyAction() {
+                                    @Override
+                                    public void run(NatTable table, KeyEvent event)
+                                    {
+                                        showUnsafeWriteNotice();
+                                    }
+                                });
                         }
                     });
                 }

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultBaseTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultBaseTableView.java
@@ -105,6 +105,7 @@ import org.eclipse.nebula.widgets.nattable.style.CellStyleAttributes;
 import org.eclipse.nebula.widgets.nattable.style.DisplayMode;
 import org.eclipse.nebula.widgets.nattable.style.HorizontalAlignmentEnum;
 import org.eclipse.nebula.widgets.nattable.style.Style;
+import org.eclipse.nebula.widgets.nattable.ui.action.IKeyAction;
 import org.eclipse.nebula.widgets.nattable.ui.action.IMouseAction;
 import org.eclipse.nebula.widgets.nattable.ui.binding.UiBindingRegistry;
 import org.eclipse.nebula.widgets.nattable.ui.matcher.CellEditorMouseEventMatcher;
@@ -119,6 +120,7 @@ import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -221,6 +223,14 @@ public abstract class DefaultBaseTableView implements TableView {
 
     /** status if file is read only. */
     protected boolean isReadOnly = false;
+
+    /**
+     * True when the dataset's datatype contains a construct whose write path
+     * is not yet symmetric with the display path (see
+     * {@link DataFactoryUtils#isUnsafeForWrite}). Editing is force-disabled
+     * and a notice is shown when the user attempts to edit.
+     */
+    protected boolean unsafeForWrite = false;
 
     /** status if the enums are to display converted. */
     protected boolean isEnumConverted = false;
@@ -410,6 +420,13 @@ public abstract class DefaultBaseTableView implements TableView {
                 if (!compression.endsWith("ENCODE_ENABLED"))
                     isReadOnly = true;
             }
+        }
+
+        if (!isReadOnly && DataFactoryUtils.isUnsafeForWrite(dataObject.getDatatype())) {
+            unsafeForWrite = true;
+            isReadOnly     = true;
+            log.info("dataObject({}) editing disabled: unsafe datatype for table-view write path",
+                     dataObject);
         }
 
         log.trace("dataObject({}) isReadOnly={}", dataObject, isReadOnly);
@@ -1276,6 +1293,33 @@ public abstract class DefaultBaseTableView implements TableView {
 
         dataProvider.setIsValueChanged(false);
         log.debug("updateValueInFile(): EXIT - value changed flag cleared");
+    }
+
+    /**
+     * Show the editing-disabled notice. Called when the user attempts to edit
+     * a cell in a dataset whose datatype has no symmetric write path (see
+     * {@link DataFactoryUtils#isUnsafeForWrite}). Throttled to one dialog per
+     * second so a held-down key or rapid clicks don't stack popups.
+     */
+    private long lastUnsafeWriteNoticeMs = 0;
+    protected final void showUnsafeWriteNotice()
+    {
+        if (!unsafeForWrite || shell == null || shell.isDisposed())
+            return;
+        long now = System.currentTimeMillis();
+        if (now - lastUnsafeWriteNoticeMs < 1000)
+            return;
+        lastUnsafeWriteNoticeMs = now;
+
+        Tools.showInformation(
+            shell, "Editing disabled",
+            "HDFView does not support editing datasets that contain any of the following:\n"
+                + "  - variable-length sequences (non-string)\n"
+                + "  - arrays of compound, array, or variable-length sequence\n"
+                + "  - arrays nested inside compound\n"
+                + "  - compounds nested inside compound\n\n"
+                + "Use a separate tool (h5py, the HDF5 C API, h5edit, etc.) to modify these "
+                + "datatypes.");
     }
 
     @Override
@@ -2546,6 +2590,36 @@ public abstract class DefaultBaseTableView implements TableView {
                                                                           new MouseEditAction());
                     }
                 });
+
+                // When the datatype's write path is not yet implemented, intercept
+                // edit attempts and show a dialog explaining what's blocked.
+                if (unsafeForWrite) {
+                    this.addConfiguration(new AbstractUiBindingConfiguration() {
+                        @Override
+                        public void configureUiBindings(UiBindingRegistry uiBindingRegistry)
+                        {
+                            uiBindingRegistry.registerFirstDoubleClickBinding(
+                                new MouseEventMatcher(SWT.NONE, GridRegion.BODY,
+                                                      MouseEventMatcher.LEFT_BUTTON),
+                                new IMouseAction() {
+                                    @Override
+                                    public void run(NatTable table, MouseEvent event)
+                                    {
+                                        showUnsafeWriteNotice();
+                                    }
+                                });
+                            uiBindingRegistry.registerFirstKeyBinding(new LetterOrDigitKeyEventMatcher(),
+                                                                      new IKeyAction() {
+                                                                          @Override
+                                                                          public void run(NatTable table,
+                                                                                          KeyEvent event)
+                                                                          {
+                                                                              showUnsafeWriteNotice();
+                                                                          }
+                                                                      });
+                        }
+                    });
+                }
             }
         }
     }

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultBaseTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultBaseTableView.java
@@ -1298,18 +1298,14 @@ public abstract class DefaultBaseTableView implements TableView {
     /**
      * Show the editing-disabled notice. Called when the user attempts to edit
      * a cell in a dataset whose datatype has no symmetric write path (see
-     * {@link DataFactoryUtils#isUnsafeForWrite}). Throttled to one dialog per
-     * second so a held-down key or rapid clicks don't stack popups.
+     * {@link DataFactoryUtils#isUnsafeForWrite}). No throttling is needed:
+     * {@link Tools#showInformation} opens a modal JFace dialog, so the calling
+     * event isn't re-entered until the user dismisses it.
      */
-    private long lastUnsafeWriteNoticeMs = 0;
     protected final void showUnsafeWriteNotice()
     {
         if (!unsafeForWrite || shell == null || shell.isDisposed())
             return;
-        long now = System.currentTimeMillis();
-        if (now - lastUnsafeWriteNoticeMs < 1000)
-            return;
-        lastUnsafeWriteNoticeMs = now;
 
         Tools.showInformation(shell, "Editing disabled",
                               "HDFView does not support editing datasets that contain any of the following:\n"

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
@@ -27,24 +27,6 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import hdf.object.CompoundDS;
-import hdf.object.CompoundDataFormat;
-import hdf.object.DataFormat;
-import hdf.object.Datatype;
-import hdf.object.FileFormat;
-import hdf.object.HObject;
-import hdf.object.ScalarDS;
-import hdf.object.h5.H5Datatype;
-import hdf.view.DataView.DataViewManager;
-import hdf.view.HDFView;
-import hdf.view.Tools;
-import hdf.view.ViewProperties;
-
-import hdf.hdf5lib.HDF5Constants;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.eclipse.nebula.widgets.nattable.NatTable;
 import org.eclipse.nebula.widgets.nattable.config.DefaultNatTableStyleConfiguration;
 import org.eclipse.nebula.widgets.nattable.config.EditableRule;
@@ -71,6 +53,22 @@ import org.eclipse.nebula.widgets.nattable.viewport.ViewportLayer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.widgets.Composite;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import hdf.hdf5lib.HDF5Constants;
+import hdf.object.CompoundDS;
+import hdf.object.CompoundDataFormat;
+import hdf.object.DataFormat;
+import hdf.object.Datatype;
+import hdf.object.FileFormat;
+import hdf.object.HObject;
+import hdf.object.ScalarDS;
+import hdf.object.h5.H5Datatype;
+import hdf.view.DataView.DataViewManager;
+import hdf.view.HDFView;
+import hdf.view.Tools;
+import hdf.view.ViewProperties;
 
 /**
  * A class to construct a CompoundDS TableView.
@@ -680,6 +678,15 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
         public void handleLayerEvent(ILayerEvent e)
         {
             if (e instanceof CellSelectionEvent) {
+                // For datatypes where the display column count has been
+                // expanded (array-of-compound, vlen-of-compound, etc.) the
+                // listener below hits a null ptr because baseIndexMap was built from the
+                // unexpanded member count. Editing is already disabled for
+                // these via unsafeForWrite, and the listener's side effects
+                // (ref preview, etc.) don't apply, so just return.
+                if (unsafeForWrite)
+                    return;
+
                 CellSelectionEvent event = (CellSelectionEvent)e;
                 boolean valIsRegRef      = false;
                 boolean valIsObjRef      = false;

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -841,8 +840,6 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
         // actually label the columns.
         private final ArrayList<String> columnNames;
 
-        private final Map<Datatype, Integer> vlenMaxLens;
-
         private final int ncols;
         private final int groupSize;
 
@@ -852,16 +849,14 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
 
             Datatype cmpdType = dataObject.getDatatype();
 
-            // Resolve VLEN(compound) to the compound base type for display purposes
-            if (cmpdType.isVLEN() && !cmpdType.isVarStr() && cmpdType.getDatatypeBase() != null &&
-                cmpdType.getDatatypeBase().isCompound()) {
-                cmpdType = cmpdType.getDatatypeBase();
-            }
-
-            List<Datatype> selectedTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, cmpdType);
+            // A top-level vlen-of-compound is a single column (the whole sequence). It is not
+            // a compound, so it has no members to filter - use it directly as the sole type.
+            List<Datatype> selectedTypes;
+            if (cmpdType.isVLEN() && !cmpdType.isVarStr())
+                selectedTypes = new ArrayList<>(java.util.Collections.singletonList(cmpdType));
+            else
+                selectedTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, cmpdType);
             final List<String> datasetMemberNames = Arrays.asList(dataFormat.getSelectedMemberNames());
-
-            vlenMaxLens = DataFactoryUtils.computeVlenMaxLens(selectedTypes, dataValue);
 
             columnNames = new ArrayList<>(dataFormat.getSelectedMemberCount());
 
@@ -960,39 +955,11 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                                            memberTypes);
             }
             else if (curDtype.isVLEN() && !curDtype.isVarStr()) {
-                // VLEN of X: expand to max_vlen columns with [i] suffix, mirroring the ARRAY branch.
-                int vlenLen       = DataFactoryUtils.getVlenExpansion(vlenMaxLens, curDtype);
-                Datatype baseType = curDtype.getDatatypeBase();
-
-                if (baseType != null && baseType.isCompound()) {
-                    if (memberTypes.isEmpty())
-                        memberTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, baseType, false);
-
-                    StringBuilder sBuilder              = new StringBuilder();
-                    ArrayList<String> nestedMemberNames = new ArrayList<>(vlenLen * memberNames.size());
-                    for (int i = 0; i < vlenLen; i++) {
-                        for (int j = 0; j < memberNames.size(); j++) {
-                            sBuilder.setLength(0);
-                            sBuilder.append(memberNames.get(j).replaceAll(CompoundDS.SEPARATOR, "->"));
-                            sBuilder.append("[").append(i).append("]");
-                            nestedMemberNames.add(sBuilder.toString());
-                        }
-                    }
-
-                    recursiveColumnHeaderSetup(outColNames, dataFormat, baseType, nestedMemberNames,
-                                               memberTypes);
-                }
-                else {
-                    StringBuilder sBuilder = new StringBuilder();
-                    for (int j = 0; j < memberNames.size(); j++) {
-                        for (int i = 0; i < vlenLen; i++) {
-                            sBuilder.setLength(0);
-                            sBuilder.append(memberNames.get(j).replaceAll(CompoundDS.SEPARATOR, "->"));
-                            sBuilder.append("[").append(i).append("]");
-                            outColNames.add(sBuilder.toString());
-                        }
-                    }
-                }
+                // A top-level vlen (including vlen-of-compound) is a single column showing
+                // the whole sequence. Never recurse into a compound base - that would create
+                // one column per inner member.
+                for (int j = 0; j < memberNames.size(); j++)
+                    outColNames.add(memberNames.get(j).replaceAll(CompoundDS.SEPARATOR, "->"));
             }
             else if (curDtype.isCompound()) {
                 /*
@@ -1014,10 +981,11 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                     boolean nestedArrayOfCompound      = false;
 
                     /*
-                     * Recursively detect any nested array/vlen of compound types and deal with them
-                     * by creating multiple copies of the member names.
+                     * Recursively detect any nested ARRAY of compound types and deal with them
+                     * by creating multiple copies of the member names. A vlen is NOT expanded -
+                     * it is a single column (handled below), so it is excluded here.
                      */
-                    if (curType.isArray() || curType.isVLEN()) {
+                    if (curType.isArray()) {
                         Datatype base = curType.getDatatypeBase();
                         while (base != null) {
                             if (base.isCompound()) {
@@ -1063,10 +1031,10 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                         remainingLeavesInTop -= namesConsumed;
                     }
                     else if (curType.isVLEN() && !curType.isVarStr()) {
-                        int vlenLen     = DataFactoryUtils.getVlenExpansion(vlenMaxLens, curType);
+                        // A vlen member is a single column showing the whole sequence as a
+                        // brace-string (VlenDataProvider recurses for nested compounds).
                         String baseName = curName.replaceAll(CompoundDS.SEPARATOR, "->");
-                        for (int i = 0; i < vlenLen; i++)
-                            outColNames.add(baseName + "[" + i + "]");
+                        outColNames.add(baseName);
                         remainingLeavesInTop--;
                     }
                     else {

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
@@ -27,6 +27,24 @@ import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import hdf.object.CompoundDS;
+import hdf.object.CompoundDataFormat;
+import hdf.object.DataFormat;
+import hdf.object.Datatype;
+import hdf.object.FileFormat;
+import hdf.object.HObject;
+import hdf.object.ScalarDS;
+import hdf.object.h5.H5Datatype;
+import hdf.view.DataView.DataViewManager;
+import hdf.view.HDFView;
+import hdf.view.Tools;
+import hdf.view.ViewProperties;
+
+import hdf.hdf5lib.HDF5Constants;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.eclipse.nebula.widgets.nattable.NatTable;
 import org.eclipse.nebula.widgets.nattable.config.DefaultNatTableStyleConfiguration;
 import org.eclipse.nebula.widgets.nattable.config.EditableRule;
@@ -53,22 +71,6 @@ import org.eclipse.nebula.widgets.nattable.viewport.ViewportLayer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.ScrolledComposite;
 import org.eclipse.swt.widgets.Composite;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import hdf.hdf5lib.HDF5Constants;
-import hdf.object.CompoundDS;
-import hdf.object.CompoundDataFormat;
-import hdf.object.DataFormat;
-import hdf.object.Datatype;
-import hdf.object.FileFormat;
-import hdf.object.HObject;
-import hdf.object.ScalarDS;
-import hdf.object.h5.H5Datatype;
-import hdf.view.DataView.DataViewManager;
-import hdf.view.HDFView;
-import hdf.view.Tools;
-import hdf.view.ViewProperties;
 
 /**
  * A class to construct a CompoundDS TableView.

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
@@ -1036,9 +1036,8 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                             // synthesize the inner-compound leaf names from the declared
                             // member-name list, using the header as prefix.
                             String baseName = curName.replaceAll(CompoundDS.SEPARATOR, "->");
-                            selMemberNames =
-                                buildInnerCompoundLeafNames(nestedArrayOfCompoundType, baseName);
-                            namesConsumed = 1;
+                            selMemberNames = buildInnerCompoundLeafNames(nestedArrayOfCompoundType, baseName);
+                            namesConsumed  = 1;
                         }
                         else {
                             // Array-of-compound: flat list has header + each inner leaf name.

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -831,6 +832,8 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
         // actually label the columns.
         private final ArrayList<String> columnNames;
 
+        private final Map<Datatype, Integer> vlenMaxLens;
+
         private final int ncols;
         private final int groupSize;
 
@@ -848,6 +851,8 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
 
             List<Datatype> selectedTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, cmpdType);
             final List<String> datasetMemberNames = Arrays.asList(dataFormat.getSelectedMemberNames());
+
+            vlenMaxLens = DataFactoryUtils.computeVlenMaxLens(selectedTypes, dataValue);
 
             columnNames = new ArrayList<>(dataFormat.getSelectedMemberCount());
 
@@ -911,7 +916,8 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                  * architectural issue.
                  */
                 if (memberTypes.isEmpty()) {
-                    memberTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, nestedCompoundType);
+                    memberTypes =
+                        DataFactoryUtils.filterNonSelectedMembers(dataFormat, nestedCompoundType, false);
                 }
 
                 /*
@@ -945,25 +951,56 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                                            memberTypes);
             }
             else if (curDtype.isVLEN() && !curDtype.isVarStr()) {
-                /*
-                 * For VLEN of COMPOUND, peel off the VLEN wrapper and recurse with the
-                 * compound base type. Each cell displays the variable-length values as a
-                 * brace-enclosed list, so no column multiplication is needed.
-                 */
+                // VLEN of X: expand to max_vlen columns with [i] suffix, mirroring the ARRAY branch.
+                int vlenLen       = DataFactoryUtils.getVlenExpansion(vlenMaxLens, curDtype);
                 Datatype baseType = curDtype.getDatatypeBase();
+
                 if (baseType != null && baseType.isCompound()) {
-                    if (memberTypes.isEmpty()) {
-                        memberTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, baseType);
+                    if (memberTypes.isEmpty())
+                        memberTypes = DataFactoryUtils.filterNonSelectedMembers(dataFormat, baseType, false);
+
+                    StringBuilder sBuilder              = new StringBuilder();
+                    ArrayList<String> nestedMemberNames = new ArrayList<>(vlenLen * memberNames.size());
+                    for (int i = 0; i < vlenLen; i++) {
+                        for (int j = 0; j < memberNames.size(); j++) {
+                            sBuilder.setLength(0);
+                            sBuilder.append(memberNames.get(j).replaceAll(CompoundDS.SEPARATOR, "->"));
+                            sBuilder.append("[").append(i).append("]");
+                            nestedMemberNames.add(sBuilder.toString());
+                        }
                     }
-                    recursiveColumnHeaderSetup(outColNames, dataFormat, baseType, memberNames, memberTypes);
+
+                    recursiveColumnHeaderSetup(outColNames, dataFormat, baseType, nestedMemberNames,
+                                               memberTypes);
+                }
+                else {
+                    StringBuilder sBuilder = new StringBuilder();
+                    for (int j = 0; j < memberNames.size(); j++) {
+                        for (int i = 0; i < vlenLen; i++) {
+                            sBuilder.setLength(0);
+                            sBuilder.append(memberNames.get(j).replaceAll(CompoundDS.SEPARATOR, "->"));
+                            sBuilder.append("[").append(i).append("]");
+                            outColNames.add(sBuilder.toString());
+                        }
+                    }
                 }
             }
             else if (curDtype.isCompound()) {
+                /*
+                 * memberNames is the flat list of leaf names; memberTypes is the list of
+                 * top-level member types. Advance through memberTypes one slot at a time,
+                 * consuming countLeafNames(topType) flat names per slot.
+                 */
                 ListIterator<String> localIt = memberNames.listIterator();
+                int topIdx                   = 0;
+                int remainingLeavesInTop     = DataFactoryUtils.countLeafNames(memberTypes.get(0));
                 while (localIt.hasNext()) {
-                    int curIdx                         = localIt.nextIndex();
+                    if (remainingLeavesInTop <= 0 && topIdx + 1 < memberTypes.size()) {
+                        topIdx++;
+                        remainingLeavesInTop = DataFactoryUtils.countLeafNames(memberTypes.get(topIdx));
+                    }
                     String curName                     = localIt.next();
-                    Datatype curType                   = memberTypes.get(curIdx % memberTypes.size());
+                    Datatype curType                   = memberTypes.get(topIdx);
                     Datatype nestedArrayOfCompoundType = null;
                     boolean nestedArrayOfCompound      = false;
 
@@ -989,27 +1026,84 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                      * members n times, where n is the number of array or vlen elements.
                      */
                     if (nestedArrayOfCompound) {
-                        List<Datatype> selTypes =
-                            DataFactoryUtils.filterNonSelectedMembers(dataFormat, nestedArrayOfCompoundType);
-                        List<String> selMemberNames = new ArrayList<>(selTypes.size());
+                        List<Datatype> selTypes = DataFactoryUtils.filterNonSelectedMembers(
+                            dataFormat, nestedArrayOfCompoundType, false);
 
-                        int arrCmpdLen = calcArrayOfCompoundLen(selTypes);
-                        for (int i = 0; i < arrCmpdLen; i++) {
-                            selMemberNames.add(localIt.next());
+                        List<String> selMemberNames;
+                        int namesConsumed;
+                        if (curType.isVLEN()) {
+                            // Vlen wraps the flat name list at the header level only;
+                            // synthesize the inner-compound leaf names from the declared
+                            // member-name list, using the header as prefix.
+                            String baseName = curName.replaceAll(CompoundDS.SEPARATOR, "->");
+                            selMemberNames =
+                                buildInnerCompoundLeafNames(nestedArrayOfCompoundType, baseName);
+                            namesConsumed = 1;
+                        }
+                        else {
+                            // Array-of-compound: flat list has header + each inner leaf name.
+                            selMemberNames = new ArrayList<>(selTypes.size());
+                            int arrCmpdLen = calcArrayOfCompoundLen(selTypes);
+                            selMemberNames.add(curName);
+                            for (int i = 1; i < arrCmpdLen; i++)
+                                selMemberNames.add(localIt.next());
+                            namesConsumed = arrCmpdLen;
                         }
 
                         recursiveColumnHeaderSetup(outColNames, dataFormat, curType, selMemberNames,
                                                    selTypes);
+                        remainingLeavesInTop -= namesConsumed;
+                    }
+                    else if (curType.isVLEN() && !curType.isVarStr()) {
+                        int vlenLen     = DataFactoryUtils.getVlenExpansion(vlenMaxLens, curType);
+                        String baseName = curName.replaceAll(CompoundDS.SEPARATOR, "->");
+                        for (int i = 0; i < vlenLen; i++)
+                            outColNames.add(baseName + "[" + i + "]");
+                        remainingLeavesInTop--;
                     }
                     else {
                         // Copy the dataset member name reference, so changes to the column name
                         // don't affect the dataset's internal member names.
                         curName = new String(curName.replaceAll(CompoundDS.SEPARATOR, "->"));
-
                         outColNames.add(curName);
+                        remainingLeavesInTop--;
                     }
                 }
             }
+        }
+
+        /**
+         * Produce "prefix-&gt;leaf" names for each leaf of {@code innerCompound}.
+         * Used by the vlen-of-compound header path, whose flat name list contains
+         * only the wrapper header rather than per-leaf entries.
+         */
+        private List<String> buildInnerCompoundLeafNames(Datatype innerCompound, String prefix)
+        {
+            List<String> out = new ArrayList<>();
+            appendInnerCompoundLeafNames(innerCompound, prefix, out);
+            return out;
+        }
+
+        private void appendInnerCompoundLeafNames(Datatype t, String prefix, List<String> out)
+        {
+            if (t == null)
+                return;
+            if (t.isCompound()) {
+                List<String> names      = t.getCompoundMemberNames();
+                List<Datatype> children = t.getCompoundMemberTypes();
+                if (names == null || children == null)
+                    return;
+                for (int i = 0; i < names.size(); i++) {
+                    String childName = prefix + "->" + names.get(i);
+                    Datatype childT  = children.get(i);
+                    if (childT != null && childT.isCompound())
+                        appendInnerCompoundLeafNames(childT, childName, out);
+                    else
+                        out.add(childName);
+                }
+                return;
+            }
+            out.add(prefix);
         }
 
         private int calcArrayOfCompoundLen(List<Datatype> datatypes)
@@ -1157,10 +1251,12 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
                     }
                     else if (allColumnNames[i].matches(".*\\[[0-9]*\\]")) {
                         /*
-                         * Top-level ARRAY of COMPOUND types.
+                         * Top-level array/vlen of an atomic base. Each element is a single
+                         * column, so group them all under the member name rather than a
+                         * generic per-element "ARRAY[i]" group.
                          */
-                        columnHeaderBuilder.append("ARRAY");
-                        processArrayOfCompound(columnHeaderBuilder, allColumnNames[i]);
+                        String baseName = allColumnNames[i].replaceAll("\\[[0-9]*\\]$", "");
+                        columnHeaderBuilder.append(baseName);
 
                         columnGroupHeaderLayer.addColumnsIndexesToGroup(columnHeaderBuilder.toString(),
                                                                         colindex);

--- a/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
+++ b/hdfview/src/main/java/hdf/view/TableView/DefaultCompoundDSTableView.java
@@ -679,151 +679,152 @@ public class DefaultCompoundDSTableView extends DefaultBaseTableView implements 
         public void handleLayerEvent(ILayerEvent e)
         {
             if (e instanceof CellSelectionEvent) {
-                // For datatypes where the display column count has been
-                // expanded (array-of-compound, vlen-of-compound, etc.) the
-                // listener below hits a null ptr because baseIndexMap was built from the
-                // unexpanded member count. Editing is already disabled for
-                // these via unsafeForWrite, and the listener's side effects
-                // (ref preview, etc.) don't apply, so just return.
-                if (unsafeForWrite)
-                    return;
-
-                CellSelectionEvent event = (CellSelectionEvent)e;
-                boolean valIsRegRef      = false;
-                boolean valIsObjRef      = false;
-
-                HashMap<Integer, Integer> baseIndexMap;
-                HashMap<Integer, Integer> relCmpdStartIndexMap;
-
-                CompoundDataFormat dataFormat = (CompoundDataFormat)dataObject;
-                Datatype cmpdType             = dataObject.getDatatype();
-
-                // Resolve VLEN(compound) to compound base type
-                if (cmpdType.isVLEN() && !cmpdType.isVarStr() && cmpdType.getDatatypeBase() != null &&
-                    cmpdType.getDatatypeBase().isCompound()) {
-                    cmpdType = cmpdType.getDatatypeBase();
-                }
-
-                Datatype[] selectedMemberTypes = dataFormat.getSelectedMemberTypes();
-                List<Datatype> localSelectedTypes =
-                    DataFactoryUtils.filterNonSelectedMembers(dataFormat, cmpdType);
-
-                HashMap<Integer, Integer>[] maps = null;
                 try {
-                    maps = DataFactoryUtils.buildIndexMaps(dataFormat, localSelectedTypes);
+                    refineCellValuePreview((CellSelectionEvent)e);
                 }
                 catch (Exception ex) {
-                    log.debug("CompoundDSCellSelectionListener: buildIndexMaps", ex);
+                    // For datatypes where the display column count has been expanded
+                    // (array-of-compound, vlen-of-compound, etc.), baseIndexMap is built
+                    // from the unexpanded member count and a lookup below can go out of
+                    // range. This only refines the read-only cell-value preview text, so
+                    // failing safe here (skip the refinement) is fine regardless of
+                    // whether the datatype also happens to be unsafe for writing.
+                    log.debug("CompoundDSCellSelectionListener: unable to refine cell value preview", ex);
                 }
-                baseIndexMap         = maps[DataFactoryUtils.COL_TO_BASE_CLASS_MAP_INDEX];
-                relCmpdStartIndexMap = maps[DataFactoryUtils.CMPD_START_IDX_MAP_INDEX];
-
-                if (baseIndexMap.size() == 0) {
-                    log.debug("base index mapping is invalid - size 0");
-                }
-
-                if (relCmpdStartIndexMap.size() == 0) {
-                    log.debug("compound field start index mapping is invalid - size 0");
-                }
-
-                /*
-                 * nCols should represent the number of columns covered by this CompoundData
-                 * only. For top-level CompoundData, this should be the entire width of the
-                 * dataset. For nested CompoundData, nCols will be a subset of these columns.
-                 */
-                int nCols = (int)dataFormat.getWidth() * baseIndexMap.size();
-                int nRows = (int)dataFormat.getHeight();
-
-                int nSubColumns = (int)dataFormat.getWidth();
-                int fieldIndex  = event.getColumnPosition();
-                int rowIdx      = event.getRowPosition();
-
-                if (nSubColumns > 1) { // multi-dimension compound dataset
-                    /*
-                     * Make sure fieldIdx is within a valid range, since even for multi-dimensional
-                     * compound datasets there will only be as many lists of data as there are
-                     * members in a single compound type.
-                     */
-                    fieldIndex %= selectedMemberTypes.length;
-                    if (fieldIndex == 0)
-                        fieldIndex = selectedMemberTypes.length;
-
-                    int realColIdx = event.getColumnPosition() / selectedMemberTypes.length;
-                    rowIdx         = event.getRowPosition() * nSubColumns + realColIdx;
-                }
-                log.trace("CompoundDSCellSelectionListener: CellSelected fieldIndex={}:{}", rowIdx,
-                          fieldIndex);
-
-                int bIndex      = baseIndexMap.get(fieldIndex - 1);
-                Object colValue = ((List<?>)dataValue).get(bIndex);
-                if (colValue == null)
-                    log.debug("CompoundDSCellSelectionListener: CellSelected colValue is null for Idx={}",
-                              bIndex);
-
-                Datatype selectedType = selectedMemberTypes[bIndex];
-
-                if (selectedType.isRef()) {
-                    valIsRegRef = (selectedType.getDatatypeSize() == HDF5Constants.H5R_DSET_REG_REF_BUF_SIZE);
-                    valIsObjRef = (selectedType.getDatatypeSize() == HDF5Constants.H5R_OBJ_REF_BUF_SIZE);
-                }
-
-                int rowStart  = ((RowHeaderDataProvider)rowHeaderDataProvider).start;
-                int rowStride = ((RowHeaderDataProvider)rowHeaderDataProvider).stride;
-
-                int rowIndex = rowStart + indexBase +
-                               dataTable.getRowIndexByPosition(event.getRowPosition()) * rowStride;
-                Object fieldName = columnHeaderDataProvider.getDataValue(
-                    dataTable.getColumnIndexByPosition(event.getColumnPosition()), 0);
-
-                String colIndex = "";
-                if (dataObject.getWidth() > 1) {
-                    int groupSize = ((CompoundDataFormat)dataObject).getSelectedMemberCount();
-                    colIndex =
-                        "[" +
-                        String.valueOf((dataTable.getColumnIndexByPosition(event.getColumnPosition())) /
-                                       groupSize) +
-                        "]";
-                }
-                Object val =
-                    dataTable.getDataValueByPosition(event.getColumnPosition(), event.getRowPosition());
-
-                cellLabel.setText(String.valueOf(rowIndex) + ", " + fieldName + colIndex + " =  ");
-
-                if (val == null) {
-                    cellValueField.setText("Null");
-                    return;
-                }
-
-                String strVal = null;
-                if (valIsRegRef) {
-                    boolean displayValues = ViewProperties.showRegRefValues();
-
-                    if (val != null && ((String)val).compareTo("NULL") != 0) {
-                        strVal = (String)val;
-                    }
-                    else {
-                        strVal = null;
-                    }
-                }
-                else if (valIsObjRef) {
-                    if (val != null && ((String)val).compareTo("NULL") != 0) {
-                        strVal = (String)val;
-                    }
-                    else {
-                        strVal = null;
-                    }
-                }
-
-                ILayerCell cell = dataTable.getCellByPosition(((CellSelectionEvent)e).getColumnPosition(),
-                                                              ((CellSelectionEvent)e).getRowPosition());
-                strVal =
-                    dataDisplayConverter.canonicalToDisplayValue(cell, dataTable.getConfigRegistry(), val)
-                        .toString();
-
-                cellValueField.setText(strVal);
-                ((ScrolledComposite)cellValueField.getParent())
-                    .setMinSize(cellValueField.computeSize(SWT.DEFAULT, SWT.DEFAULT));
             }
+        }
+
+        private void refineCellValuePreview(CellSelectionEvent event) throws Exception
+        {
+            boolean valIsRegRef = false;
+            boolean valIsObjRef = false;
+
+            HashMap<Integer, Integer> baseIndexMap;
+            HashMap<Integer, Integer> relCmpdStartIndexMap;
+
+            CompoundDataFormat dataFormat = (CompoundDataFormat)dataObject;
+            Datatype cmpdType             = dataObject.getDatatype();
+
+            // Resolve VLEN(compound) to compound base type
+            if (cmpdType.isVLEN() && !cmpdType.isVarStr() && cmpdType.getDatatypeBase() != null &&
+                cmpdType.getDatatypeBase().isCompound()) {
+                cmpdType = cmpdType.getDatatypeBase();
+            }
+
+            Datatype[] selectedMemberTypes = dataFormat.getSelectedMemberTypes();
+            List<Datatype> localSelectedTypes =
+                DataFactoryUtils.filterNonSelectedMembers(dataFormat, cmpdType);
+
+            HashMap<Integer, Integer>[] maps = null;
+            try {
+                maps = DataFactoryUtils.buildIndexMaps(dataFormat, localSelectedTypes);
+            }
+            catch (Exception ex) {
+                log.debug("CompoundDSCellSelectionListener: buildIndexMaps", ex);
+            }
+            baseIndexMap         = maps[DataFactoryUtils.COL_TO_BASE_CLASS_MAP_INDEX];
+            relCmpdStartIndexMap = maps[DataFactoryUtils.CMPD_START_IDX_MAP_INDEX];
+
+            if (baseIndexMap.size() == 0) {
+                log.debug("base index mapping is invalid - size 0");
+            }
+
+            if (relCmpdStartIndexMap.size() == 0) {
+                log.debug("compound field start index mapping is invalid - size 0");
+            }
+
+            /*
+             * nCols should represent the number of columns covered by this CompoundData
+             * only. For top-level CompoundData, this should be the entire width of the
+             * dataset. For nested CompoundData, nCols will be a subset of these columns.
+             */
+            int nCols = (int)dataFormat.getWidth() * baseIndexMap.size();
+            int nRows = (int)dataFormat.getHeight();
+
+            int nSubColumns = (int)dataFormat.getWidth();
+            int fieldIndex  = event.getColumnPosition();
+            int rowIdx      = event.getRowPosition();
+
+            if (nSubColumns > 1) { // multi-dimension compound dataset
+                /*
+                 * Make sure fieldIdx is within a valid range, since even for multi-dimensional
+                 * compound datasets there will only be as many lists of data as there are
+                 * members in a single compound type.
+                 */
+                fieldIndex %= selectedMemberTypes.length;
+                if (fieldIndex == 0)
+                    fieldIndex = selectedMemberTypes.length;
+
+                int realColIdx = event.getColumnPosition() / selectedMemberTypes.length;
+                rowIdx         = event.getRowPosition() * nSubColumns + realColIdx;
+            }
+            log.trace("CompoundDSCellSelectionListener: CellSelected fieldIndex={}:{}", rowIdx, fieldIndex);
+
+            int bIndex      = baseIndexMap.get(fieldIndex - 1);
+            Object colValue = ((List<?>)dataValue).get(bIndex);
+            if (colValue == null)
+                log.debug("CompoundDSCellSelectionListener: CellSelected colValue is null for Idx={}",
+                          bIndex);
+
+            Datatype selectedType = selectedMemberTypes[bIndex];
+
+            if (selectedType.isRef()) {
+                valIsRegRef = (selectedType.getDatatypeSize() == HDF5Constants.H5R_DSET_REG_REF_BUF_SIZE);
+                valIsObjRef = (selectedType.getDatatypeSize() == HDF5Constants.H5R_OBJ_REF_BUF_SIZE);
+            }
+
+            int rowStart  = ((RowHeaderDataProvider)rowHeaderDataProvider).start;
+            int rowStride = ((RowHeaderDataProvider)rowHeaderDataProvider).stride;
+
+            int rowIndex =
+                rowStart + indexBase + dataTable.getRowIndexByPosition(event.getRowPosition()) * rowStride;
+            Object fieldName = columnHeaderDataProvider.getDataValue(
+                dataTable.getColumnIndexByPosition(event.getColumnPosition()), 0);
+
+            String colIndex = "";
+            if (dataObject.getWidth() > 1) {
+                int groupSize = ((CompoundDataFormat)dataObject).getSelectedMemberCount();
+                colIndex      = "[" +
+                           String.valueOf((dataTable.getColumnIndexByPosition(event.getColumnPosition())) /
+                                          groupSize) +
+                           "]";
+            }
+            Object val = dataTable.getDataValueByPosition(event.getColumnPosition(), event.getRowPosition());
+
+            cellLabel.setText(String.valueOf(rowIndex) + ", " + fieldName + colIndex + " =  ");
+
+            if (val == null) {
+                cellValueField.setText("Null");
+                return;
+            }
+
+            String strVal = null;
+            if (valIsRegRef) {
+                boolean displayValues = ViewProperties.showRegRefValues();
+
+                if (val != null && ((String)val).compareTo("NULL") != 0) {
+                    strVal = (String)val;
+                }
+                else {
+                    strVal = null;
+                }
+            }
+            else if (valIsObjRef) {
+                if (val != null && ((String)val).compareTo("NULL") != 0) {
+                    strVal = (String)val;
+                }
+                else {
+                    strVal = null;
+                }
+            }
+
+            ILayerCell cell = dataTable.getCellByPosition(event.getColumnPosition(), event.getRowPosition());
+            strVal = dataDisplayConverter.canonicalToDisplayValue(cell, dataTable.getConfigRegistry(), val)
+                         .toString();
+
+            cellValueField.setText(strVal);
+            ((ScrolledComposite)cellValueField.getParent())
+                .setMinSize(cellValueField.computeSize(SWT.DEFAULT, SWT.DEFAULT));
         }
     }
 

--- a/object/src/main/java/hdf/object/h5/H5CompoundDS.java
+++ b/object/src/main/java/hdf/object/h5/H5CompoundDS.java
@@ -1262,6 +1262,17 @@ public class H5CompoundDS extends CompoundDS implements MetaDataContainer {
 
                     H5.H5DreadVL(dsetID, compTid, spaceIDs[0], spaceIDs[1], HDF5Constants.H5P_DEFAULT,
                                  (Object[])memberData);
+
+                    // H5DreadVL was called with a single-field compound transfer type, so
+                    // each row comes back wrapped in a one-element record. Unwrap to expose
+                    // the payload directly.
+                    if (memberType.isVLEN()) {
+                        Object[] rows = (Object[])memberData;
+                        for (int r = 0; r < rows.length; r++) {
+                            if (rows[r] instanceof java.util.ArrayList<?> rec && rec.size() == 1)
+                                rows[r] = rec.get(0);
+                        }
+                    }
                 }
                 else {
                     log.trace(

--- a/object/src/main/java/hdf/object/h5/H5CompoundDS.java
+++ b/object/src/main/java/hdf/object/h5/H5CompoundDS.java
@@ -1214,10 +1214,10 @@ public class H5CompoundDS extends CompoundDS implements MetaDataContainer {
                         (spaceIDs[0] == HDF5Constants.H5P_DEFAULT) ? "H5P_DEFAULT" : spaceIDs[0],
                         (spaceIDs[1] == HDF5Constants.H5P_DEFAULT) ? "H5P_DEFAULT" : spaceIDs[1]);
 
+                    // Slots are left null: H5DreadVL installs a freshly
+                    // allocated ArrayList into each slot.
                     @SuppressWarnings("rawtypes")
                     ArrayList[] vlBuf = new ArrayList[nSelPoints];
-                    for (int j = 0; j < nSelPoints; j++)
-                        vlBuf[j] = new ArrayList<>();
 
                     H5.H5DreadVL(dsetID, compTid, spaceIDs[0], spaceIDs[1], HDF5Constants.H5P_DEFAULT, vlBuf);
 

--- a/object/src/main/java/hdf/object/h5/H5CompoundDS.java
+++ b/object/src/main/java/hdf/object/h5/H5CompoundDS.java
@@ -944,14 +944,41 @@ public class H5CompoundDS extends CompoundDS implements MetaDataContainer {
         }
         else if (cmpdType.isVLEN() && !cmpdType.isVarStr()) {
             /*
-             * For VLEN of COMPOUND, peel off the VLEN wrapper and recurse with the compound
-             * base type. The actual VLEN reading is handled in readSingleCompoundMember(),
-             * which detects the VLEN wrapper via dsDatatype.isVLEN() and uses H5DreadVL.
+             * Top-level VLEN-of-compound is displayed as a SINGLE column showing the whole
+             * sequence (e.g. [{1, 2}, {3, 4}]), consistent with how a vlen member of a
+             * compound is shown. Read the whole vlen in one H5DreadVL call; the JNI parses
+             * each compound element into nested Lists (e.g. [[1, 2], [3, 4]]), exactly the
+             * shape VlenDataProvider/VlenDataDisplayConverter render. The dataset enumerates
+             * a single member (see H5Datatype.extractCompoundInfo), so we return one column.
              */
-            Datatype baseType = cmpdType.getDatatypeBase();
-            if (baseType != null && baseType.isCompound()) {
-                theData = compoundTypeIO(ioType, did, spaceIDs, nSelPoints, (H5Datatype)baseType, writeBuf,
-                                         globalMemberIndex);
+            if (ioType == H5File.IO_TYPE.READ) {
+                long wholeTid = -1;
+                try {
+                    wholeTid = H5.H5Dget_type(did);
+                    @SuppressWarnings("rawtypes")
+                    ArrayList[] vlBuf = new ArrayList[nSelPoints];
+                    H5.H5DreadVL(did, wholeTid, spaceIDs[0], spaceIDs[1], HDF5Constants.H5P_DEFAULT, vlBuf);
+                    globalMemberIndex[0]++;
+                    theData = vlBuf;
+                }
+                catch (HDF5DataFiltersException exfltr) {
+                    log.debug("compoundTypeIO(): top-level VLEN read failure: ", exfltr);
+                    throw new HDF5Exception("Filter not available exception: " + exfltr.getMessage());
+                }
+                catch (Exception ex) {
+                    log.debug("compoundTypeIO(): top-level VLEN read failure: ", ex);
+                    throw new HDF5Exception("failed to read VLEN-of-compound dataset: " + ex.getMessage());
+                }
+                finally {
+                    if (wholeTid >= 0) {
+                        try {
+                            H5.H5Tclose(wholeTid);
+                        }
+                        catch (Exception ex) {
+                            log.debug("compoundTypeIO(): H5Tclose(wholeTid {}) failure: ", wholeTid, ex);
+                        }
+                    }
+                }
             }
         }
         else if (cmpdType.isCompound()) {

--- a/object/src/main/java/hdf/object/h5/H5Datatype.java
+++ b/object/src/main/java/hdf/object/h5/H5Datatype.java
@@ -2166,11 +2166,10 @@ public class H5Datatype extends Datatype {
         else if (dtype.isVLEN()) {
             log.trace("allocateArray(): isVLEN");
 
+            // Slots are left null: the JNI read routines (H5DreadVL/H5AreadVL)
+            // install a freshly allocated ArrayList into each slot. Callers must
+            // not pre-allocate the per-element lists.
             data = new ArrayList[numPoints];
-            for (int j = 0; j < numPoints; j++)
-                ((ArrayList[])data)[j] = new ArrayList<byte[]>();
-            // if (baseType != null)
-            // ((ArrayList<>)data).add(H5Datatype.allocateArray(baseType, numPoints));
         }
         else if (typeClass == CLASS_ARRAY) {
             log.trace("allocateArray(): class CLASS_ARRAY");

--- a/object/src/main/java/hdf/object/h5/H5Datatype.java
+++ b/object/src/main/java/hdf/object/h5/H5Datatype.java
@@ -2974,9 +2974,15 @@ public class H5Datatype extends Datatype {
             H5Datatype.extractCompoundInfo((H5Datatype)dtype.getDatatypeBase(), name, names, flatListTypes);
         }
         else if (dtype.isVLEN() && !dtype.isVarStr()) {
-            log.trace(
-                "extractCompoundInfo(): variable-length type - extracting compound info from base datatype");
-            H5Datatype.extractCompoundInfo((H5Datatype)dtype.getDatatypeBase(), name, names, flatListTypes);
+            /*
+             * A vlen (including vlen-of-compound) is a single leaf: it is displayed as one
+             * column showing the whole sequence as a string. Do NOT recurse into the base
+             * compound - that would enumerate the inner members as separate columns.
+             */
+            log.trace("extractCompoundInfo(): variable-length type - adding as a single leaf");
+            if (names != null)
+                names.add(name);
+            flatListTypes.add(dtype);
         }
         else if (dtype.isCompound()) {
             List<String> compoundMemberNames   = dtype.getCompoundMemberNames();

--- a/object/src/main/java/hdf/object/h5/H5Datatype.java
+++ b/object/src/main/java/hdf/object/h5/H5Datatype.java
@@ -2009,6 +2009,46 @@ public class H5Datatype extends Datatype {
      * @throws OutOfMemoryError
      *                          If there is a failure.
      */
+    /**
+     * Whether {@code t} contains a variable-length sequence or variable-length string
+     * anywhere in its type tree - recursing through ARRAY bases and COMPOUND members to
+     * any depth (e.g. ARRAY of ARRAY of variable-length string, or a COMPOUND with a
+     * variable-length member). This mirrors the detection the JNI itself performs in
+     * h5str_detect_vlen()/h5str_detect_vlen_str() (h5util.c) to decide whether an I/O
+     * call is handled by translate_rbuf()/translate_wbuf(), which read such data into
+     * java.util.ArrayList containers rather than narrowly-typed arrays.
+     *
+     * Note a COMPOUND of only fixed-size members is NOT variable-length: it is read
+     * through the plain packed-buffer path, so it must not be reported here.
+     *
+     * @param t the type.
+     * @return true if a top-level Object[]/ArrayList container is required to read this
+     *         type, rather than a narrowly-typed array.
+     */
+    public static boolean containsVlenOrVarStr(final Datatype t)
+    {
+        if (t == null)
+            return false;
+        // isVLEN() already covers isVarStr(): a variable-length string sets isVLEN
+        // true too (see fromNative()). Checked here regardless, since that coupling
+        // is this class's implementation detail, not part of the Datatype contract.
+        if (t.isVarStr() || t.isVLEN())
+            return true;
+        if (t.isArray())
+            return containsVlenOrVarStr(t.getDatatypeBase());
+        if (t.isCompound()) {
+            List<Datatype> members = t.getCompoundMemberTypes();
+            if (members != null) {
+                for (Datatype m : members) {
+                    if (containsVlenOrVarStr(m))
+                        return true;
+                }
+            }
+            return false;
+        }
+        return false;
+    }
+
     public static final Object allocateArray(final H5Datatype dtype, int numPoints)
         throws OutOfMemoryError, HDF5Exception
     {
@@ -2177,17 +2217,31 @@ public class H5Datatype extends Datatype {
             try {
                 log.trace("allocateArray(): ArrayRank={}", dtype.getArrayDims().length);
 
-                // Use the base datatype to define the array
-                long[] arrayDims = dtype.getArrayDims();
-                int asize        = numPoints;
-                for (int j = 0; j < arrayDims.length; j++) {
-                    log.trace("allocateArray(): Array dims[{}]={}", j, arrayDims[j]);
-
-                    asize *= arrayDims[j];
+                if (baseType != null && containsVlenOrVarStr(baseType)) {
+                    // The base type reads as an ArrayList per element (per the JNI's
+                    // documented buffer data model - see translate_rbuf() in h5util.c),
+                    // e.g. ARRAY of variable-length string/sequence/compound, or an
+                    // ARRAY of ARRAY of one of those. A flat, narrowly-typed buffer
+                    // (e.g. String[]) can't hold an ArrayList: the JNI's
+                    // SetObjectArrayElement call throws, and translate_rbuf's exception
+                    // handling silently discards it, leaving the buffer empty. Slots are
+                    // left null: H5DreadVL/H5AreadVL install a freshly allocated
+                    // ArrayList into each slot.
+                    data = new Object[numPoints];
                 }
+                else {
+                    // Use the base datatype to define the array
+                    long[] arrayDims = dtype.getArrayDims();
+                    int asize        = numPoints;
+                    for (int j = 0; j < arrayDims.length; j++) {
+                        log.trace("allocateArray(): Array dims[{}]={}", j, arrayDims[j]);
 
-                if (baseType != null)
-                    data = H5Datatype.allocateArray(baseType, asize);
+                        asize *= arrayDims[j];
+                    }
+
+                    if (baseType != null)
+                        data = H5Datatype.allocateArray(baseType, asize);
+                }
             }
             catch (Exception ex) {
                 log.debug("allocateArray(): CLASS_ARRAY class failure: ", ex);

--- a/object/src/main/java/hdf/object/h5/H5ScalarAttr.java
+++ b/object/src/main/java/hdf/object/h5/H5ScalarAttr.java
@@ -1210,9 +1210,9 @@ public class H5ScalarAttr extends ScalarDS implements H5Attribute {
                 else if (dsDatatype.isVLEN()) {
                     log.trace("attributeCommonIO():read ioType:VLEN-REF H5Aread isArray()={}",
                               dsDatatype.isArray());
+                    // Slots are left null: H5AreadVL installs a freshly
+                    // allocated ArrayList into each slot.
                     theData = new ArrayList[(int)lsize];
-                    for (int j = 0; j < lsize; j++)
-                        ((ArrayList[])theData)[j] = new ArrayList<byte[]>();
 
                     try {
                         H5.H5AreadVL(attrID, tid, (Object[])theData);

--- a/object/src/main/java/hdf/object/h5/H5ScalarDS.java
+++ b/object/src/main/java/hdf/object/h5/H5ScalarDS.java
@@ -974,7 +974,9 @@ public class H5ScalarDS extends ScalarDS implements MetaDataContainer {
                             tid = dsDatatype.createNative();
                             log.trace("scalarDatasetCommonIO(): native type created tid={}", tid);
 
-                            if (dsDatatype.isVarStr()) {
+                            if (dsDatatype.isVarStr() ||
+                                (dsDatatype.isArray() && dsDatatype.getDatatypeBase() != null &&
+                                 dsDatatype.getDatatypeBase().isVarStr())) {
                                 log.trace(
                                     "scalarDatasetCommonIO(): H5Dread_VLStrings did={} tid={} spaceIDs[0]={} spaceIDs[1]={}",
                                     did, tid,
@@ -1125,7 +1127,9 @@ public class H5ScalarDS extends ScalarDS implements MetaDataContainer {
                     try {
                         tid = dsDatatype.createNative();
 
-                        if (dsDatatype.isVarStr()) {
+                        if (dsDatatype.isVarStr() ||
+                            (dsDatatype.isArray() && dsDatatype.getDatatypeBase() != null &&
+                             dsDatatype.getDatatypeBase().isVarStr())) {
                             log.trace(
                                 "scalarDatasetCommonIO(): H5Dwrite_VLStrings did={} tid={} spaceIDs[0]={} spaceIDs[1]={}",
                                 did, tid,

--- a/object/src/main/java/hdf/object/h5/H5ScalarDS.java
+++ b/object/src/main/java/hdf/object/h5/H5ScalarDS.java
@@ -940,9 +940,9 @@ public class H5ScalarDS extends ScalarDS implements MetaDataContainer {
                         }
                     }
                     else if (dsDatatype.isVLEN()) {
+                        // Slots are left null: H5DreadVL installs a freshly
+                        // allocated ArrayList into each slot.
                         theData = new ArrayList[(int)totalSelectedSpacePoints];
-                        for (int j = 0; j < (int)totalSelectedSpacePoints; j++)
-                            ((ArrayList[])theData)[j] = new ArrayList<byte[]>();
                     }
                     else if ((originalBuf == null) || dsDatatype.isEnum() || dsDatatype.isText() ||
                              dsDatatype.isRefObj() ||

--- a/object/src/main/java/hdf/object/h5/H5ScalarDS.java
+++ b/object/src/main/java/hdf/object/h5/H5ScalarDS.java
@@ -974,9 +974,7 @@ public class H5ScalarDS extends ScalarDS implements MetaDataContainer {
                             tid = dsDatatype.createNative();
                             log.trace("scalarDatasetCommonIO(): native type created tid={}", tid);
 
-                            if (dsDatatype.isVarStr() ||
-                                (dsDatatype.isArray() && dsDatatype.getDatatypeBase() != null &&
-                                 dsDatatype.getDatatypeBase().isVarStr())) {
+                            if (dsDatatype.isVarStr()) {
                                 log.trace(
                                     "scalarDatasetCommonIO(): H5Dread_VLStrings did={} tid={} spaceIDs[0]={} spaceIDs[1]={}",
                                     did, tid,
@@ -986,8 +984,7 @@ public class H5ScalarDS extends ScalarDS implements MetaDataContainer {
                                 H5.H5Dread_VLStrings(did, tid, spaceIDs[0], spaceIDs[1],
                                                      HDF5Constants.H5P_DEFAULT, (Object[])theData);
                             }
-                            else if (dsDatatype.isVLEN() ||
-                                     (dsDatatype.isArray() && dsDatatype.getDatatypeBase().isVLEN())) {
+                            else if (H5Datatype.containsVlenOrVarStr(dsDatatype)) {
                                 // Check for unsupported VLEN complex combination
                                 H5Datatype baseType = (H5Datatype)dsDatatype.getDatatypeBase();
                                 if (baseType != null && baseType.isComplex()) {
@@ -1127,9 +1124,7 @@ public class H5ScalarDS extends ScalarDS implements MetaDataContainer {
                     try {
                         tid = dsDatatype.createNative();
 
-                        if (dsDatatype.isVarStr() ||
-                            (dsDatatype.isArray() && dsDatatype.getDatatypeBase() != null &&
-                             dsDatatype.getDatatypeBase().isVarStr())) {
+                        if (dsDatatype.isVarStr()) {
                             log.trace(
                                 "scalarDatasetCommonIO(): H5Dwrite_VLStrings did={} tid={} spaceIDs[0]={} spaceIDs[1]={}",
                                 did, tid,
@@ -1139,8 +1134,7 @@ public class H5ScalarDS extends ScalarDS implements MetaDataContainer {
                             H5.H5Dwrite_VLStrings(did, tid, spaceIDs[0], spaceIDs[1],
                                                   HDF5Constants.H5P_DEFAULT, (Object[])tmpData);
                         }
-                        else if (dsDatatype.isVLEN() ||
-                                 (dsDatatype.isArray() && dsDatatype.getDatatypeBase().isVLEN())) {
+                        else if (H5Datatype.containsVlenOrVarStr(dsDatatype)) {
                             log.trace(
                                 "scalarDatasetCommonIO(): H5DwriteVL did={} tid={} spaceIDs[0]={} spaceIDs[1]={}",
                                 did, tid,


### PR DESCRIPTION
## Summary

This resolves the customer-reported issue that #474 set out to fix (HDFView failing to display compound datasets containing nested/variable-length members), and additionally fixes a case #474 did not handle: arrays of variable-length strings, including arrays of arrays of them.

This branch is built by taking #474's (`nested_seq_cmpd`) legitimate compound/vlen display fixes and replacing its `H5Dread_VLStrings`/`H5Dwrite_VLStrings` workaround for array-of-varstr with a fix at the actual root cause, plus fixing the underlying table-view indexing bug that workaround was papering over. If this is merged, #474 can be closed - the commits from that branch are included here (with original authorship preserved) as the first 8 commits, so this is not a duplicate/independent implementation.

## Root cause of the array-of-varstr bug

`H5Datatype.allocateArray()`'s `ARRAY` branch allocated a flat, narrowly-typed buffer (e.g. `String[]`) by delegating to the base type's own allocation. But per the JNI's documented buffer data model (`translate_rbuf()`/`translate_wbuf()` in HDF5's `h5util.c`), an `ARRAY` reads as an `ArrayList` of its elements whenever the base is itself variable-length - a flat buffer can't hold that. The resulting type mismatch throws `ArrayStoreException` inside the JNI's `SetObjectArrayElement` call, and `translate_rbuf`'s own exception handling (`CHECK_JNI_EXCEPTION(ENVONLY, JNI_TRUE)`) silently discards it, leaving the buffer empty - no error surfaces anywhere.

I confirmed this empirically with a standalone array-of-varstr reproducer built against current HDF5 `develop`: the generic `H5DreadVL`/`H5DwriteVL` path returns empty strings on read and throws `h5validate_wbuf: expected a java.util.ArrayList element` on write, with the *unmodified* buffer-allocation code. Once the caller passes the documented `Object[]` shape instead, the same JNI call reads and writes correctly - no JNI changes needed.

## Changes on top of #474's commits (net a code reduction)

- **`H5Datatype`**: new `containsVlenOrVarStr()`, mirroring the JNI's own recursive `h5str_detect_vlen()`/`h5str_detect_vlen_str()` (recurses through `ARRAY` bases and `COMPOUND` members to any depth). `allocateArray`'s `ARRAY` branch now allocates `Object[]` instead of a flat buffer when the base needs it.
- **`H5ScalarDS`**: read/write dispatch now uses the same recursive check instead of the one-level-deep `isArray() && base.isVLEN()` test, which missed `ARRAY` of `ARRAY` of variable-length string. #474's `H5Dread_VLStrings`/`H5Dwrite_VLStrings` special-casing for arrays is reverted back to plain `isVarStr()` - not needed once the buffer shape is correct.
- **`DataProviderFactory` (`ArrayDataProvider`)**: the table view's flattened-offset indexing assumed one contiguous buffer spanning all rows, which cannot describe a List-per-row layout once nesting is involved (row 0 was pulling in row 1's data, row 1 went out of bounds, both showing `*ERROR*`). Added a container-based retrieval path that addresses nested `List` elements directly by index. The existing flat-buffer path is untouched and still used for plain numeric arrays.

Also two smaller fixes from review comments on #474 that apply independently of the array fix:
- **`DefaultBaseTableView`**: `showUnsafeWriteNotice()`'s one-dialog-per-second throttle is unnecessary - `Tools.showInformation()` opens a modal dialog, so the triggering event isn't re-entered until the user dismisses it.
- **`DefaultCompoundDSTableView`**: the cell-selection listener's early return keyed off `unsafeForWrite` was unrelated to write safety - it existed to dodge a `baseIndexMap`/expanded-column mismatch. Extracted the listener body into `refineCellValuePreview()` and replaced the flag check with a targeted try/catch around the actual failure mode.

## Verification

Built HDF5 `develop` from source (Java bindings enabled) and tested against it end to end:
- Direct `H5ScalarDS`/`H5CompoundDS` probes: array-of-varstr, array-of-array-of-varstr, and compound-of-vlen-compound (the original reported bug) all read and write correctly.
- Actual HDFView table view (screenshots, clicked cells for full values): all three render correctly - e.g. the nested-array case shows `[[r0e0a, r0e0b, r0e0c], [r0e1a, r0e1b, r0e1c]]` exactly matching what was written, and the original compound-of-vlen file shows `id`/`tags`/`nested` columns with correct values - no more `*ERROR*` anywhere.
- `mvn test -pl object`: 163/163 pass, no regressions.